### PR TITLE
Add order and block

### DIFF
--- a/src/main/java/com/mikuac/shiro/annotation/common/Order.java
+++ b/src/main/java/com/mikuac/shiro/annotation/common/Order.java
@@ -1,0 +1,20 @@
+package com.mikuac.shiro.annotation.common;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 独立的优先级注解，可作用于监听函数上。
+ *
+ * @author ilxyil
+ * @version $Id: $Id
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Order {
+
+    int value() default Integer.MAX_VALUE;
+}

--- a/src/main/java/com/mikuac/shiro/common/utils/ScanUtils.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/ScanUtils.java
@@ -41,7 +41,7 @@ public class ScanUtils implements ResourceLoaderAware {
         try {
             String packageSearchPath = ResourcePatternResolver.CLASSPATH_ALL_URL_PREFIX
                     .concat(ClassUtils.convertClassNameToResourcePath(SystemPropertyUtils.resolvePlaceholders(packageName))
-                            .concat("/**/*.class"));
+                            .concat("/*.class"));
             Resource[] resources = ResourcePatternUtils.getResourcePatternResolver(resourceLoader).getResources(packageSearchPath);
             MetadataReader metadataReader;
             for (Resource resource : resources) {

--- a/src/main/java/com/mikuac/shiro/core/BotFactory.java
+++ b/src/main/java/com/mikuac/shiro/core/BotFactory.java
@@ -63,7 +63,6 @@ public class BotFactory {
         log.debug("Start creating bot instance {}", selfId);
         // 获取 Spring 容器中所有指定类型的对象
         Map<String, Object> beans = new HashMap<>(16);
-        beans.putAll(applicationContext.getBeansOfType(BotPlugin.class));
         beans.putAll(applicationContext.getBeansWithAnnotation(Shiro.class));
         // 一键多值 注解为 Key 存放所有包含某个注解的方法
         MultiValueMap<Class<? extends Annotation>, HandlerMethod> annotationHandler = new LinkedMultiValueMap<>();

--- a/src/main/java/com/mikuac/shiro/handler/injection/InjectionHandler.java
+++ b/src/main/java/com/mikuac/shiro/handler/injection/InjectionHandler.java
@@ -1,6 +1,7 @@
 package com.mikuac.shiro.handler.injection;
 
 import com.mikuac.shiro.annotation.*;
+import com.mikuac.shiro.annotation.common.Order;
 import com.mikuac.shiro.bean.HandlerMethod;
 import com.mikuac.shiro.bean.MsgChainBean;
 import com.mikuac.shiro.common.utils.InternalUtils;
@@ -19,11 +20,9 @@ import lombok.var;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Matcher;
+import java.util.stream.Collectors;
 
 /**
  * <p>InjectionHandler class.</p>
@@ -218,8 +217,12 @@ public class InjectionHandler {
      */
     public void invokeGroupMessage(@NotNull Bot bot, @NotNull GroupMessageEvent event) {
         val handlers = bot.getAnnotationHandler();
-        val handlerMethods = handlers.get(GroupMessageHandler.class);
+        List<HandlerMethod> handlerMethods = handlers.get(GroupMessageHandler.class);
         if (handlerMethods != null && !handlerMethods.isEmpty()) {
+            handlerMethods = handlerMethods.stream().
+                    sorted(Comparator.comparing(handlerMethod ->
+                            Optional.ofNullable(handlerMethod.getMethod().getAnnotation(Order.class).value()).orElse(Integer.MAX_VALUE))).
+                    collect(Collectors.toList());
             handlerMethods.forEach(handlerMethod -> {
                 val annotation = handlerMethod.getMethod().getAnnotation(GroupMessageHandler.class);
                 if (checkAt(event.getArrayMsg(), event.getSelfId(), annotation.at())) {
@@ -245,8 +248,12 @@ public class InjectionHandler {
      */
     public void invokePrivateMessage(@NotNull Bot bot, @NotNull PrivateMessageEvent event) {
         val handlers = bot.getAnnotationHandler();
-        val handlerMethods = handlers.get(PrivateMessageHandler.class);
+        List<HandlerMethod> handlerMethods = handlers.get(PrivateMessageHandler.class);
         if (handlerMethods != null && !handlerMethods.isEmpty()) {
+            handlerMethods = handlerMethods.stream().
+                    sorted(Comparator.comparing(handlerMethod ->
+                            Optional.ofNullable(handlerMethod.getMethod().getAnnotation(Order.class).value()).orElse(Integer.MAX_VALUE))).
+                    collect(Collectors.toList());
             handlerMethods.forEach(handlerMethod -> {
                 val annotation = handlerMethod.getMethod().getAnnotation(PrivateMessageHandler.class);
                 val params = matcher(annotation.cmd(), event.getMessage());


### PR DESCRIPTION
1.新增排序类注解
2.构建annotationHandler时不再处理集成BotPlugin(防止用户继承BotPlugin的情况下，还使用注解，导致消息被重复消费)
3.私聊消息与群聊消息处理前先处理handler的优先级
4.修改注解类扫描路径，防止通用型注解被扫描到