### PR TITLE
添加阻断注解，优化代码

### DIFF
--- a/src/main/java/com/mikuac/shiro/annotation/common/Break.java
+++ b/src/main/java/com/mikuac/shiro/annotation/common/Break.java
@@ -1,0 +1,15 @@
+package com.mikuac.shiro.annotation.common;
+
+
+import java.lang.annotation.*;
+
+/**
+ * 独立的处理阻断注解，可作用于监听函数上。
+ *
+ * @author ilxyil
+ * @version $Id: $Id
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Break {
+}

--- a/src/main/java/com/mikuac/shiro/handler/injection/InjectionHandler.java
+++ b/src/main/java/com/mikuac/shiro/handler/injection/InjectionHandler.java
@@ -219,14 +219,6 @@ public class InjectionHandler {
         val handlers = bot.getAnnotationHandler();
         List<HandlerMethod> handlerMethods = handlers.get(GroupMessageHandler.class);
         if (handlerMethods != null && !handlerMethods.isEmpty()) {
-
-            handlerMethods = handlerMethods.stream().sorted(
-                    Comparator.comparing(
-                            handlerMethod -> Optional.of(
-                                    handlerMethod.getMethod().getAnnotation(Order.class).value()
-                            ).orElse(Integer.MAX_VALUE))
-            ).collect(Collectors.toList());
-
             handlerMethods.forEach(handlerMethod -> {
                 val annotation = handlerMethod.getMethod().getAnnotation(GroupMessageHandler.class);
                 if (checkAt(event.getArrayMsg(), event.getSelfId(), annotation.at())) {
@@ -254,15 +246,6 @@ public class InjectionHandler {
         val handlers = bot.getAnnotationHandler();
         List<HandlerMethod> handlerMethods = handlers.get(PrivateMessageHandler.class);
         if (handlerMethods != null && !handlerMethods.isEmpty()) {
-
-            handlerMethods = handlerMethods.stream().sorted(
-                    Comparator.comparing(
-                            handlerMethod -> Optional.of(
-                                    handlerMethod.getMethod().getAnnotation(Order.class).value()
-                            ).orElse(Integer.MAX_VALUE)
-                    )
-            ).collect(Collectors.toList());
-
             handlerMethods.forEach(handlerMethod -> {
                 val annotation = handlerMethod.getMethod().getAnnotation(PrivateMessageHandler.class);
                 val params = matcher(annotation.cmd(), event.getMessage());


### PR DESCRIPTION
1.添加阻断注解，支持注解开发模式下的处理阻断
2.删除原有群消息和私聊消息处的排序逻辑，统一在注解收集处处理。这样不管什么类型的消息处理都能实现排序和阻断，不用重新写处理逻辑

建议：
1.不要使用val，会降低代码可读性，没法直接显性的了解当前调用方法的返回值类型
2.可以使用策略模式+责任链模式优化过多的switch或者if