### PR TITLE
消息过滤功能, 群消息事件中 GroupSender 的 userId 类型

### DIFF
--- a/src/main/java/com/mikuac/shiro/common/utils/GroupMessageFilterUtil.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/GroupMessageFilterUtil.java
@@ -1,0 +1,27 @@
+package com.mikuac.shiro.common.utils;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+public class GroupMessageFilterUtil {
+    private static final ConcurrentHashMap<Integer, Long> CACHE = new ConcurrentHashMap<>();
+
+    // 插入消息并指定缓存时间
+    public static boolean insertMessageId(Integer messageId, int cacheTime) {
+        long now = System.currentTimeMillis();
+        removeExpiredMessageId(now);
+        if (CACHE.containsKey(messageId)) {
+            long cacheNow = CACHE.get(messageId);
+            if (cacheNow + cacheTime >= now) {
+                return false;
+            }
+            return false;
+        }
+        CACHE.put(messageId, now + cacheTime);
+        return true;
+    }
+    // 超出缓存时间后清理缓存
+    public static void removeExpiredMessageId(long time) {
+        CACHE.entrySet()
+                .removeIf(entry -> entry.getValue() < time);
+    }
+}

--- a/src/main/java/com/mikuac/shiro/dto/event/message/GroupMessageEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/message/GroupMessageEvent.java
@@ -43,7 +43,7 @@ public class GroupMessageEvent extends MessageEvent {
     public static class GroupSender {
 
         @JSONField(name = "user_id")
-        private String userId;
+        private Long userId;
 
         @JSONField(name = "nickname")
         private String nickname;

--- a/src/main/java/com/mikuac/shiro/properties/ShiroProperties.java
+++ b/src/main/java/com/mikuac/shiro/properties/ShiroProperties.java
@@ -32,6 +32,22 @@ public class ShiroProperties {
     private Class<? extends BotMessageEventInterceptor> interceptor = DefaultBotMessageEventInterceptor.class;
 
     /**
+     * 如果多个 oneBot 实例同时连接,是否对相同的消息事件去重(先到优先),true 为仅触发第一个事件
+     * 比如多个 bot 实例在同一个群中,同一个人发送的消息会在每个 bot 实例都触发一次事件,开启后将只收到第一个事件
+     * 仅过滤群组消息,私聊消息不可能会重复
+     */
+    private Boolean groupEventFilter = false;
+    /**
+     * 在开启 groupEventFilter 的情况下,此选项控制是否过滤连接到框架的其他实例的qq号发出的消息
+     */
+    private Boolean groupSelfBotEventFilter = true;
+    /**
+     * 如果开启重复的群聊消息过滤,设定缓存的毫秒数时间
+     * 也就是当多少毫秒之后如果受到重复的群聊消息 则剔除
+     */
+    private Integer groupEventFilterTime = 500;
+
+    /**
      * 日志等级设置为 debug
      */
     private Boolean debug = false;


### PR DESCRIPTION
增加多个 onebot 实例同时连接时,且在统一群组中的情况下,过滤相同群消息的功能,不过**此功能默认关闭**,无需修改.
群消息事件中 `GroupSender` 的 `userId` 类型由 `String` 改为 `Long` 类型