### PR TITLE
添加get_status api，fix一个启动时可能遇到的错误

### DIFF
--- a/src/main/java/com/mikuac/shiro/common/utils/RegexUtils.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/RegexUtils.java
@@ -1,8 +1,8 @@
 package com.mikuac.shiro.common.utils;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -17,7 +17,7 @@ public class RegexUtils {
     private RegexUtils() {
     }
 
-    private static final Map<String, Pattern> cache = new HashMap<>();
+    private static final Map<String, Pattern> cache = new ConcurrentHashMap<>();
 
     /**
      * 正则匹配

--- a/src/main/java/com/mikuac/shiro/core/Bot.java
+++ b/src/main/java/com/mikuac/shiro/core/Bot.java
@@ -1130,4 +1130,14 @@ public class Bot {
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
+    /**
+     * 获取状态
+     *
+     * @return result {@link GetStatusResp}
+     */
+    public GetStatusResp getStatus() {
+        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_STATUS, null);
+        return result != null ? result.to(new TypeReference<ActionData<GetStatusResp>>() {
+        }).getData() : null;
+    }
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/GetStatusResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/GetStatusResp.java
@@ -1,0 +1,103 @@
+package com.mikuac.shiro.dto.action.response;
+
+import com.alibaba.fastjson2.annotation.JSONField;
+import lombok.Data;
+
+/**
+ * @author Neo
+ * @date 2023/7/26
+ */
+@Data
+public class GetStatusResp {
+
+    /**
+     * 原 CQHTTP 字段, 恒定为 true
+     */
+    @JSONField(name = "app_initialized")
+    private Boolean appInitialized;
+
+    /**
+     * 原 CQHTTP 字段, 恒定为 true
+     */
+    @JSONField(name = "app_enabled")
+    private Boolean appEnabled;
+
+    /**
+     * 原 CQHTTP 字段
+     */
+    @JSONField(name = "plugins_good")
+    private Boolean pluginsGood;
+
+    /**
+     * 原 CQHTTP 字段, 恒定为 true
+     */
+    @JSONField(name = "app_good")
+    private Boolean appGood;
+
+    /**
+     * 表示BOT是否在线
+     */
+    private Boolean online;
+
+    /**
+     * 同 online
+     */
+    private Boolean good;
+
+    /**
+     * 运行统计
+     */
+    private Statistics stat;
+
+    @Data
+    public static class Statistics {
+
+        /**
+         * 收到的数据包总数
+         */
+        @JSONField(name = "packet_received")
+        private Long packetReceived;
+
+        /**
+         * 发送的数据包总数
+         */
+        @JSONField(name = "packet_sent")
+        private Long packetSent;
+
+        /**
+         * 数据包丢失总数
+         */
+        @JSONField(name = "packet_lost")
+        private Integer packetLost;
+
+        /**
+         * 接受信息总数
+         */
+        @JSONField(name = "message_received")
+        private Long messageReceived;
+
+        /**
+         * 发送信息总数
+         */
+        @JSONField(name = "message_sent")
+        private Long messageSent;
+
+        /**
+         * TCP 链接断开次数
+         */
+        @JSONField(name = "disconnect_times")
+        private Integer disconnectTimes;
+
+        /**
+         * 账号掉线次数
+         */
+        @JSONField(name = "lost_times")
+        private Integer lostTimes;
+
+        /**
+         * 最后一条消息时间
+         */
+        @JSONField(name = "last_message_time")
+        private Long lastMessageTime;
+    }
+}

--- a/src/main/java/com/mikuac/shiro/enums/ActionPathEnum.java
+++ b/src/main/java/com/mikuac/shiro/enums/ActionPathEnum.java
@@ -261,7 +261,12 @@ public enum ActionPathEnum implements ActionPath {
     /**
      * 发送好友赞
      */
-    SEND_LIKE("send_like");
+    SEND_LIKE("send_like"),
+    /**
+     * 获取状态
+     */
+    GET_STATUS("get_status"),
+    ;
 
     /**
      * 请求路径


### PR DESCRIPTION
- 添加一个主动获取运行状态的api
- 修复一个启动时会遇到的问题：
go-cqhttp在反向ws连接丢失后，默认情况下在这期间bot接收到的消息会在cqhttp的队列中

当Shiro启动连接上cqhttp后，cqhttp会同时将队列的消息推送到Shiro，这里使用HashMap的话就会报ConcurrentModificationException

`
Pattern pattern = cache.computeIfAbsent(regex, Pattern::compile);
`