### PR TITLE
是否开启shiro线程池配置

### DIFF
--- a/src/main/java/com/mikuac/shiro/properties/TaskPoolProperties.java
+++ b/src/main/java/com/mikuac/shiro/properties/TaskPoolProperties.java
@@ -16,6 +16,11 @@ import org.springframework.stereotype.Component;
 public class TaskPoolProperties {
 
     /**
+     * 是否启用shiro的线程池, 无配置或者 true 为开启, 默认值开启
+     */
+    private Boolean enableTaskPool = true;
+
+    /**
      * 线程池名前缀
      */
     private String threadNamePrefix = "ShiroTaskPool-";

--- a/src/main/java/com/mikuac/shiro/task/ShiroTaskPoolConfig.java
+++ b/src/main/java/com/mikuac/shiro/task/ShiroTaskPoolConfig.java
@@ -2,6 +2,7 @@ package com.mikuac.shiro.task;
 
 import com.mikuac.shiro.properties.TaskPoolProperties;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -30,6 +31,7 @@ public class ShiroTaskPoolConfig {
      * @return {@link ThreadPoolTaskExecutor}
      */
     @Bean("shiroTaskExecutor")
+    @ConditionalOnProperty(value = "shiro.task-pool.enable-task-pool" , havingValue = "true", matchIfMissing = true)
     public ThreadPoolTaskExecutor shiroTaskExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(taskPoolProperties.getCorePoolSize());


### PR DESCRIPTION
增加一项配置,用于控制是否创建用于异步的线程池,此项配置目的是如果用户自己配置了线程池,可以选择关闭项目创建的`shiroTaskExecutor`线程池.


**此项配置默认开启,也就是没有特意配置的情况下不会有任何影响 **,即使配置项为空也是默认创建 `shiroTaskExecutor`线程池,
`@Async("shiroTaskExecutor")`将会优先寻找 bean name 为 `shiroTaskExecutor` 的`ThreadPoolTaskExecutor`类,未找到的情况下再使用其他的(用户自己配置并创建的)`ThreadPoolTaskExecutor`