### PR TITLE
新增两种异常类型, 一个功能, 当ws session断开后允许等待一段时间恢复

### DIFF
--- a/src/main/java/com/mikuac/shiro/boot/ShiroAutoConfiguration.java
+++ b/src/main/java/com/mikuac/shiro/boot/ShiroAutoConfiguration.java
@@ -42,6 +42,7 @@ public class ShiroAutoConfiguration implements WebSocketConfigurer {
     @Autowired
     public void setShiroProperties(ShiroProperties shiroProperties) {
         this.shiroProperties = shiroProperties;
+        WebSocketHandler.setWaitWebsocketConnect(shiroProperties.getWaitBotConnect());
     }
 
     private WebSocketHandler webSocketHandler;

--- a/src/main/java/com/mikuac/shiro/exception/ShiroException.java
+++ b/src/main/java/com/mikuac/shiro/exception/ShiroException.java
@@ -16,4 +16,21 @@ public class ShiroException extends RuntimeException {
         super(cause);
     }
 
+    /**
+     * session 断联状态, 但是会尝试恢复.
+     */
+    public static class SendMessageException extends ShiroException {
+        public SendMessageException() {
+            super("session been closed, but you can attempt again later.");
+        }
+    }
+
+    /**
+     * session 断联, 且未恢复.
+     */
+    public static class SessionCloseException extends ShiroException {
+        public SessionCloseException() {
+            super("session been closed.");
+        }
+    }
 }

--- a/src/main/java/com/mikuac/shiro/handler/WebSocketHandler.java
+++ b/src/main/java/com/mikuac/shiro/handler/WebSocketHandler.java
@@ -175,13 +175,14 @@ public class WebSocketHandler extends TextWebSocketHandler {
                     sessionContext.clear();
                     session.close();
                 } else {
-                    this.handleFirstConnect(xSelfId, session);
+                    var bot = this.handleFirstConnect(xSelfId, session);
+                    botContainer.robots.put(xSelfId, bot);
                 }
                 return;
             }
             botContainer.robots.compute(xSelfId, (id, bot) -> {
                 if (Objects.isNull(bot)) {
-                    this.handleFirstConnect(xSelfId, session);
+                    bot = this.handleFirstConnect(xSelfId, session);
                 } else {
                     this.handleReConnect(bot, xSelfId, session);
                 }
@@ -244,13 +245,13 @@ public class WebSocketHandler extends TextWebSocketHandler {
     }
 
     @SneakyThrows
-    private void handleFirstConnect(long xSelfId, WebSocketSession session){
+    private Bot handleFirstConnect(long xSelfId, WebSocketSession session){
         // if the session has never connected
         // or has been handled
         log.info("Account {} connected", xSelfId);
         var bot = botFactory.createBot(xSelfId, session);
         coreEvent.online(bot);
-        botContainer.robots.put(xSelfId, bot);
+        return bot;
     }
 
     @SneakyThrows

--- a/src/main/java/com/mikuac/shiro/handler/WebSocketHandler.java
+++ b/src/main/java/com/mikuac/shiro/handler/WebSocketHandler.java
@@ -44,7 +44,18 @@ public class WebSocketHandler extends TextWebSocketHandler {
     private static final String SESSION_STATUS_KEY        = "session_status";
 
     public enum SessionStatus {
-        Online, Offline, Die
+        /**
+         * 正常在线
+         */
+        Online,
+        /**
+         * 断开连接, 等待重连状态
+         */
+        Offline,
+        /**
+         * 断开连接, 不会恢复
+         */
+        Die
     }
 
     private final EventHandler eventHandler;
@@ -266,8 +277,8 @@ public class WebSocketHandler extends TextWebSocketHandler {
         bot.setSession(session);
     }
 
-    public static SessionStatus getSessionStatus(Bot bot) {
-        var sessionContext = bot.getSession().getAttributes();
+    public static SessionStatus getSessionStatus(WebSocketSession session) {
+        var sessionContext = session.getAttributes();
         Object statusObj = sessionContext.getOrDefault(SESSION_STATUS_KEY, SessionStatus.Die);
         if (statusObj instanceof SessionStatus status) {
             return status;

--- a/src/main/java/com/mikuac/shiro/properties/ShiroProperties.java
+++ b/src/main/java/com/mikuac/shiro/properties/ShiroProperties.java
@@ -50,6 +50,15 @@ public class ShiroProperties {
     private Integer groupEventFilterTime = 500;
 
     /**
+     * 当发生掉线后, 等待重新连接的时间, 如果小于或等于0, 则不等待, 单位为秒数
+     * 用于在处理 event 时, bot 因网络波动掉线, event 实例中的 bot 不可用(无法发送消息)
+     * 开启后, 掉线后则等待重新上线, 若重新连接则可以继续发送消息
+     * 注意, 如果掉线还未连接期间发送消息, 因为无法预见是否会重新连接, 所以发送仍然会失败, 仅重新连接成功后才正常发送消息
+     * p.s. 一般用于bot连接不稳定, 且经常处理耗时任务, 防止断开后再也无法响应消息
+     */
+    private Integer waitBotConnect = 0;
+
+    /**
      * 日志等级设置为 debug
      */
     private Boolean debug = false;


### PR DESCRIPTION
异常 `ShiroException.SendMessageException`  发送时session已断开, 但是在等待恢复期间.
异常 `ShiroException.SessionCloseException` 发送时session无法恢复.
配置 `shiro.wait-bot-connect` 当一个ws掉线时允许等待连接恢复的时间, 默认为0(即关闭等待) 单位为秒数.

p.s. 遇到ShiroException.SendMessageException异常可以稍后重试, 此类型的异常应该在应用层调用时捕获并处理异常, 或者可以增加一项配置, 开启后, 可以等待重连的情况由框架阻塞线程,自动重试?