### PR TITLE
fix: 处理一些bug

### DIFF
--- a/src/main/java/com/mikuac/shiro/common/utils/GroupMessageFilterUtils.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/GroupMessageFilterUtils.java
@@ -17,10 +17,12 @@ public class GroupMessageFilterUtils {
     // 插入消息并指定缓存时间
     public static boolean insertMessage(GroupMessageEvent messageEvent, int cacheTime) {
         // 消息缓存
-        ByteBuffer buffer = ByteBuffer.wrap(messageEvent.getRawMessage().getBytes(StandardCharsets.UTF_8));
-        // 针对发送群以及发送者加盐, 防止误伤复读消息
+        byte[] messageByte = messageEvent.getRawMessage().getBytes(StandardCharsets.UTF_8);
+        ByteBuffer buffer = ByteBuffer.allocate(messageByte.length + 16);
+        buffer.put(messageByte);
         buffer.putLong(messageEvent.getGroupId());
         buffer.putLong(messageEvent.getSender().getUserId());
+        // 针对发送群以及发送者加盐, 防止误伤复读消息
         String md5 = DigestUtils.md5DigestAsHex(buffer.array());
         long now = System.currentTimeMillis();
         removeExpiredMessageId(now);

--- a/src/main/java/com/mikuac/shiro/common/utils/ShiroUtils.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/ShiroUtils.java
@@ -229,12 +229,13 @@ public class ShiroUtils {
      * @return CQ Code
      */
     public static String arrayMsgToCode(ArrayMsg arrayMsg) {
+        StringBuilder builder = new StringBuilder();
         if (Objects.isNull(arrayMsg.getType()) || MsgTypeEnum.unknown.equals(arrayMsg.getType())) {
             // 未知类型的消息, 忽略?
-            return "";
+            builder.append("[CQ:unknown");
+        } else {
+            builder.append("[CQ:").append(arrayMsg.getType());
         }
-        StringBuilder builder = new StringBuilder();
-        builder.append("[CQ:").append(arrayMsg.getType());
         arrayMsg.getData().forEach((k, v) -> builder.append(",").append(k).append("=").append(v));
         builder.append("]");
         return builder.toString();

--- a/src/main/java/com/mikuac/shiro/common/utils/ShiroUtils.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/ShiroUtils.java
@@ -229,6 +229,10 @@ public class ShiroUtils {
      * @return CQ Code
      */
     public static String arrayMsgToCode(ArrayMsg arrayMsg) {
+        if (Objects.isNull(arrayMsg.getType()) || MsgTypeEnum.unknown.equals(arrayMsg.getType())) {
+            // 未知类型的消息, 忽略?
+            return "";
+        }
         StringBuilder builder = new StringBuilder();
         builder.append("[CQ:").append(arrayMsg.getType());
         arrayMsg.getData().forEach((k, v) -> builder.append(",").append(k).append("=").append(v));
@@ -246,7 +250,8 @@ public class ShiroUtils {
     public static String arrayMsgToCode(List<ArrayMsg> arrayMsgs) {
         StringBuilder builder = new StringBuilder();
         for (ArrayMsg item : arrayMsgs) {
-            if (!item.getType().equals(MsgTypeEnum.text)) {
+            // 使用 Shamrock 框架仍然会出现类型不存在的消息
+            if (!MsgTypeEnum.text.equals(item.getType())) {
                 builder.append("[CQ:").append(item.getType());
                 item.getData().forEach((k, v) -> builder.append(",").append(k).append("=").append(ShiroUtils.escape(v)));
                 builder.append("]");

--- a/src/main/java/com/mikuac/shiro/core/Bot.java
+++ b/src/main/java/com/mikuac/shiro/core/Bot.java
@@ -873,6 +873,19 @@ public class Bot {
     }
 
     /**
+     * 自定义请求
+     *
+     * @param action 请求路径
+     * @param params 请求参数
+     * @return result {@link ActionData}
+     */
+    public <T> ActionData<T> customRequest(ActionPath action, Map<String, Object> params, Class<T> clazz) {
+        JSONObject result = actionHandler.action(session, action, params);
+        return result != null ? result.to(new TypeReference<ActionData<T>>() {
+        }.getType()) : null;
+    }
+
+    /**
      * 获取精华消息列表
      *
      * @param groupId 群号

--- a/src/main/java/com/mikuac/shiro/handler/WebSocketHandler.java
+++ b/src/main/java/com/mikuac/shiro/handler/WebSocketHandler.java
@@ -235,7 +235,11 @@ public class WebSocketHandler extends TextWebSocketHandler {
     protected void handleTextMessage(@NonNull WebSocketSession session, TextMessage message) {
         long xSelfId = parseSelfId(session);
         JSONObject result = JSON.parseObject(message.getPayload());
-        log.debug("[Event] {}", result.toJSONString());
+        if (!message.getPayload().contains("base64://")) {
+            log.debug("[Event] {}", result.toJSONString());
+        } else {
+            log.debug("[Event] {}", result.toJSONString().replaceAll("base64://.*]", "base64]"));
+        }
         // if resp contains echo field, this resp is action resp, else event resp.
         if (result.containsKey(API_RESULT_KEY)) {
             if (FAILED_STATUS.equals(result.get(RESULT_STATUS_KEY))) {


### PR DESCRIPTION
Bot: 自定义请求增加返回类型的泛型限定, 用于解决无法进一步转换结果的问题
GroupMessageFilterUtils: ByteBuffer.warp 实际上是映射原来的字节数组, 由于String不可变导致加盐时报错(低级错误, 汗流浃背了)
ShiroUtils: 不知是不是 OpenShamrock 的问题, 仍然有少量的消息不包含 type? 导致出现空指针异常