### PR TITLE
:sparkles: Support send list message

### DIFF
--- a/src/main/java/com/mikuac/shiro/common/utils/ArrayMsgUtil.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/ArrayMsgUtil.java
@@ -1,0 +1,217 @@
+package com.mikuac.shiro.common.utils;
+
+import com.mikuac.shiro.model.ArrayMsg;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+public class ArrayMsgUtil extends MsgUtils {
+    private final List<ArrayMsg> builder = new ArrayList<>();
+
+    @Override
+    public MsgUtils text(String text) {
+        builder.add(getJsonData("text", m -> m.put("text", text)));
+        return this;
+    }
+
+    @Override
+    public MsgUtils img(String img) {
+        builder.add(getJsonData("image", m -> m.put("file", ShiroUtils.escape(img))));
+        return this;
+    }
+
+    @Override
+    public MsgUtils img(OneBotMedia media) {
+        builder.add(getJsonData("image", media::escape));
+        return this;
+    }
+
+    @Override
+    public MsgUtils video(String video, String cover) {
+        builder.add(getJsonData("video", m -> {
+            m.put("file", ShiroUtils.escape(video));
+            m.put("cover", ShiroUtils.escape(cover));
+        }));
+        return this;
+    }
+
+    @Override
+    public MsgUtils flashImg(String img) {
+        builder.add(getJsonData("image", m -> {
+            m.put("flash", "flash");
+            m.put("file", ShiroUtils.escape(img));
+        }));
+        return this;
+    }
+
+    @Override
+    public MsgUtils face(int id) {
+        builder.add(getJsonData("face", m -> m.put("id", String.valueOf(id))));
+        return this;
+    }
+
+    @Override
+    public MsgUtils voice(OneBotMedia media) {
+        builder.add(getJsonData("record", media::escape));
+        return this;
+    }
+
+    @Override
+    public MsgUtils voice(String voice) {
+        builder.add(getJsonData("record", m -> m.put("file", ShiroUtils.escape(voice))));
+        return this;
+    }
+
+    @Override
+    public MsgUtils at(long userId) {
+        builder.add(getJsonData("at", m -> m.put("qq", String.valueOf(userId))));
+        return this;
+    }
+
+    @Override
+    public MsgUtils atAll() {
+        builder.add(getJsonData("at", m -> m.put("qq", "all")));
+        return this;
+    }
+
+    @Override
+    public MsgUtils poke(long userId) {
+        builder.add(getJsonData("poke", m -> m.put("qq", String.valueOf(userId))));
+        return this;
+    }
+
+    @Override
+    public MsgUtils reply(int msgId) {
+        builder.add(getJsonData("reply", m -> m.put("id", String.valueOf(msgId))));
+        return this;
+    }
+
+    @Override
+    public MsgUtils reply(String msgId) {
+        builder.add(getJsonData("reply", m -> m.put("id", msgId)));
+        return this;
+    }
+
+    @Override
+    public MsgUtils gift(long userId, int giftId) {
+        builder.add(getJsonData("gift", m -> {
+            m.put("qq", String.valueOf(userId));
+            m.put("id", String.valueOf(giftId));
+        }));
+        return this;
+    }
+
+    @Override
+    public MsgUtils tts(String text) {
+        builder.add(getJsonData("tts", m -> m.put("text", text)));
+        return this;
+    }
+
+    @Override
+    public MsgUtils xml(String data) {
+        builder.add(getJsonData("xml", m -> m.put("data", data)));
+        return this;
+    }
+
+    @Override
+    public MsgUtils xml(String data, int resId) {
+        builder.add(getJsonData("xml", m -> {
+            m.put("data", String.valueOf(data));
+            m.put("resid", String.valueOf(resId));
+        }));
+        return this;
+    }
+
+    @Override
+    public MsgUtils json(String data) {
+        builder.add(getJsonData("json", m -> m.put("data", data)));
+        return this;
+    }
+
+    @Override
+    public MsgUtils json(String data, int resId) {
+        builder.add(getJsonData("json", m -> {
+            m.put("data", String.valueOf(data));
+            m.put("resid", String.valueOf(resId));
+        }));
+        return this;
+    }
+
+    @Override
+    public MsgUtils cardImage(String file) {
+        builder.add(getJsonData("cardimage", m -> m.put("file", String.valueOf(file))));
+        return this;
+    }
+
+    @Override
+    public MsgUtils cardImage(String file, long minWidth, long minHeight, long maxWidth, long maxHeight, String source, String icon) {
+        builder.add(getJsonData("cardimage", m -> {
+            m.put("file", ShiroUtils.escape(file));
+            m.put("minwidth", String.valueOf(minHeight));
+            m.put("minheight", String.valueOf(minHeight));
+            m.put("maxwidth", String.valueOf(maxWidth));
+            m.put("maxheight", String.valueOf(maxHeight));
+            m.put("source", ShiroUtils.escape(source));
+            m.put("icon", ShiroUtils.escape(icon));
+        }));
+        return this;
+    }
+
+    @Override
+    public MsgUtils music(String type, long id) {
+        builder.add(getJsonData("music", m -> {
+            m.put("type", String.valueOf(type));
+            m.put("id", String.valueOf(id));
+        }));
+        return this;
+    }
+
+    @Override
+    public MsgUtils customMusic(String url, String audio, String title, String content, String image) {
+        builder.add(getJsonData("music", m -> {
+            m.put("type", "custom");
+            m.put("url", ShiroUtils.escape(url));
+            m.put("audio", ShiroUtils.escape(audio));
+            m.put("title", ShiroUtils.escape(title));
+            m.put("content", ShiroUtils.escape(content));
+            m.put("image", ShiroUtils.escape(image));
+        }));
+        return this;
+    }
+
+    @Override
+    public MsgUtils customMusic(String url, String audio, String title) {
+        builder.add(getJsonData("music", m -> {
+            m.put("type", "custom");
+            m.put("url", ShiroUtils.escape(url));
+            m.put("audio", ShiroUtils.escape(audio));
+            m.put("title", ShiroUtils.escape(title));
+        }));
+        return this;
+    }
+
+    @Override
+    public MsgUtils rps(int value) {
+        builder.add(getJsonData("rps", m -> m.put("value", String.valueOf(value))));
+        return this;
+    }
+
+    @Override
+    public String build() {
+        return builder.stream().map(ArrayMsg::toCqCode).collect(Collectors.joining());
+    }
+
+    public List<ArrayMsg> buildList() {
+        return builder;
+    }
+
+    private ArrayMsg getJsonData(String type, Consumer<Map<String, String>> consumer) {
+        HashMap<String, String> data = new HashMap<>();
+        consumer.accept(data);
+        return new ArrayMsg().setRowType(type).setData(data);
+    }
+}

--- a/src/main/java/com/mikuac/shiro/common/utils/OneBotMedia.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/OneBotMedia.java
@@ -1,5 +1,7 @@
 package com.mikuac.shiro.common.utils;
 
+import java.util.Map;
+
 /**
  * <p>OneBotMedia class.</p>
  *
@@ -55,6 +57,19 @@ public class OneBotMedia {
             stringBuilder.append(",timeout=").append(this.timeout);
         }
         return stringBuilder.toString();
+    }
+
+    public void escape(Map<String, String> map) {
+        map.put("file", this.file);
+        if (this.cache != null) {
+        map.put("cache", Boolean.TRUE.equals(this.cache) ? "1" : "0");
+        }
+        if (this.proxy != null) {
+        map.put("proxy", Boolean.TRUE.equals(this.proxy) ? "1" : "0");
+        }
+        if (this.timeout != null) {
+        map.put("timeout", this.timeout.toString());
+        }
     }
 
     /**

--- a/src/main/java/com/mikuac/shiro/core/Bot.java
+++ b/src/main/java/com/mikuac/shiro/core/Bot.java
@@ -9,6 +9,7 @@ import com.mikuac.shiro.dto.event.message.AnyMessageEvent;
 import com.mikuac.shiro.enums.ActionPath;
 import com.mikuac.shiro.enums.ActionPathEnum;
 import com.mikuac.shiro.handler.ActionHandler;
+import com.mikuac.shiro.model.ArrayMsg;
 import com.mikuac.shiro.model.HandlerMethod;
 import lombok.Getter;
 import lombok.Setter;
@@ -104,6 +105,15 @@ public class Bot {
         return result != null ? result.to(new TypeReference<ActionData<MsgId>>() {
         }.getType()) : null;
     }
+    public ActionData<MsgId> sendPrivateMsg(long userId, List<ArrayMsg> msg, boolean autoEscape) {
+        JSONObject params = new JSONObject();
+        params.put(ActionParams.USER_ID, userId);
+        params.put(ActionParams.MESSAGE, msg);
+        params.put(ActionParams.AUTO_ESCAPE, autoEscape);
+        JSONObject result = actionHandler.action(session, ActionPathEnum.SEND_PRIVATE_MSG, params);
+        return result != null ? result.to(new TypeReference<ActionData<MsgId>>() {
+        }.getType()) : null;
+    }
 
     /**
      * 临时会话
@@ -115,6 +125,16 @@ public class Bot {
      * @return result {@link ActionData} of {@link MsgId}
      */
     public ActionData<MsgId> sendPrivateMsg(long groupId, long userId, String msg, boolean autoEscape) {
+        JSONObject params = new JSONObject();
+        params.put(ActionParams.GROUP_ID, groupId);
+        params.put(ActionParams.USER_ID, userId);
+        params.put(ActionParams.MESSAGE, msg);
+        params.put(ActionParams.AUTO_ESCAPE, autoEscape);
+        JSONObject result = actionHandler.action(session, ActionPathEnum.SEND_PRIVATE_MSG, params);
+        return result != null ? result.to(new TypeReference<ActionData<MsgId>>() {
+        }.getType()) : null;
+    }
+    public ActionData<MsgId> sendPrivateMsg(long groupId, long userId, List<ArrayMsg> msg, boolean autoEscape) {
         JSONObject params = new JSONObject();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.USER_ID, userId);
@@ -142,6 +162,15 @@ public class Bot {
         return result != null ? result.to(new TypeReference<ActionData<MsgId>>() {
         }.getType()) : null;
     }
+    public ActionData<MsgId> sendGroupMsg(long groupId, List<ArrayMsg> msg, boolean autoEscape) {
+        JSONObject params = new JSONObject();
+        params.put(ActionParams.GROUP_ID, groupId);
+        params.put(ActionParams.MESSAGE, msg);
+        params.put(ActionParams.AUTO_ESCAPE, autoEscape);
+        JSONObject result = actionHandler.action(session, ActionPathEnum.SEND_GROUP_MSG, params);
+        return result != null ? result.to(new TypeReference<ActionData<MsgId>>() {
+        }.getType()) : null;
+    }
 
     /**
      * 发送群消息
@@ -153,6 +182,16 @@ public class Bot {
      * @return result {@link ActionData} of {@link MsgId}
      */
     public ActionData<MsgId> sendGroupMsg(long groupId, long userId, String msg, boolean autoEscape) {
+        JSONObject params = new JSONObject();
+        params.put(ActionParams.GROUP_ID, groupId);
+        params.put(ActionParams.USER_ID, userId);
+        params.put(ActionParams.MESSAGE, msg);
+        params.put(ActionParams.AUTO_ESCAPE, autoEscape);
+        JSONObject result = actionHandler.action(session, ActionPathEnum.SEND_GROUP_MSG, params);
+        return result != null ? result.to(new TypeReference<ActionData<MsgId>>() {
+        }.getType()) : null;
+    }
+    public ActionData<MsgId> sendGroupMsg(long groupId, long userId, List<ArrayMsg> msg, boolean autoEscape) {
         JSONObject params = new JSONObject();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.USER_ID, userId);

--- a/src/main/java/com/mikuac/shiro/model/ArrayMsg.java
+++ b/src/main/java/com/mikuac/shiro/model/ArrayMsg.java
@@ -14,8 +14,41 @@ import java.util.Map;
 @Accessors(chain = true)
 public class ArrayMsg {
 
-    private MsgTypeEnum type;
+    private String type;
 
     private Map<String, String> data;
 
+    public MsgTypeEnum getType() {
+        return MsgTypeEnum.typeOf(type);
+    }
+
+    public ArrayMsg setType(MsgTypeEnum typeEnum) {
+        type = typeEnum.name();
+        return this;
+    }
+
+    public String getRowType() {
+        return type;
+    }
+
+    public ArrayMsg setRowType(String type) {
+        this.type = type;
+        return this;
+    }
+
+    public String toCqCode() {
+        if ("text".equalsIgnoreCase(type)) {
+            return data.getOrDefault("text", "");
+        }
+        StringBuilder stringBuilder = new StringBuilder("[CQ:");
+        stringBuilder.append(getRowType());
+        data.forEach((key, val) -> {
+            stringBuilder.append(',');
+            stringBuilder.append(key);
+            stringBuilder.append('=');
+            stringBuilder.append(val);
+        });
+        stringBuilder.append(']');
+        return stringBuilder.toString();
+    }
 }


### PR DESCRIPTION
用ArrayMsgUtil可以构造消息, 但是由于 onebot 实现不一样, 有些类型的消息可能不支持发送, 或者出现可以收不能发的问题

另外ArrayMsgUtil继承于MsgUtil, 可以安全的替换(本来想直接替换), 发送消息使用新方法, 或许可以加个开关强制使包含 cq 码的消息转换成数组消息( 已知 [OnebotApi-Js](https://github.com/2891954521/LiteLoaderQQNT-OneBotApi-JS/blob/main/doc/message.md) 明确不支持 cq 码)