### PR TITLE
🎨 Added noCache support for getGroupMemberList.

### DIFF
--- a/src/main/java/com/mikuac/shiro/action/GoCQHTTPExtend.java
+++ b/src/main/java/com/mikuac/shiro/action/GoCQHTTPExtend.java
@@ -355,4 +355,13 @@ public interface GoCQHTTPExtend {
      * @return result {@link ActionRaw}
      */
     ActionRaw deleteGroupFile(long groupId, String fileId, int busId);
+
+    /**
+     * 获取群成员列表
+     *
+     * @param groupId 群号
+     * @param noCache 是否无视缓存
+     * @return result {@link ActionList} of {@link GroupMemberInfoResp}
+     */
+    ActionList<GroupMemberInfoResp> getGroupMemberList(long groupId, boolean noCache);
 }

--- a/src/main/java/com/mikuac/shiro/core/Bot.java
+++ b/src/main/java/com/mikuac/shiro/core/Bot.java
@@ -740,6 +740,23 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
     }
 
     /**
+     * 获取群成员列表
+     *
+     * @param groupId 群号
+     * @param noCache 是否不使用缓存（使用缓存可能更新不及时，但响应更快）
+     * @return result {@link ActionList} of {@link GroupMemberInfoResp}
+     */
+    @Override
+    public ActionList<GroupMemberInfoResp> getGroupMemberList(long groupId, boolean noCache) {
+        JSONObject params = new JSONObject();
+        params.put(ActionParams.GROUP_ID, groupId);
+        params.put(ActionParams.NO_CACHE, noCache);
+        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_GROUP_MEMBER_LIST, params);
+        return result != null ? result.to(new TypeReference<ActionList<GroupMemberInfoResp>>() {
+        }.getType()) : null;
+    }
+
+    /**
      * 获取群荣誉信息
      *
      * @param groupId 群号


### PR DESCRIPTION
[支持 go-cqhttp 无缓存获取群成员列表](https://docs.go-cqhttp.org/api/#%E8%8E%B7%E5%8F%96%E7%BE%A4%E6%88%90%E5%91%98%E5%88%97%E8%A1%A8)

## `get_group_member_list` 获取群成员列表

### 参数

| 字段名 | 数据类型 | 默认值 | 说明 |
| ----- | ------- | ----- | --- |
| `group_id` | number (int64) | - | 群号 |
| `no_cache` | boolean | -| 是否不使用缓存（使用缓存可能更新不及时, 但响应更快） |


