### PR TITLE
给MessageEvent添加Raw字段

### DIFF
--- a/src/main/java/com/mikuac/shiro/dto/event/message/MessageEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/message/MessageEvent.java
@@ -41,4 +41,11 @@ public class MessageEvent extends Event {
 
     private List<ArrayMsg> arrayMsg;
 
+    @JSONField(name = "raw")
+    private Raw raw;
+
+    @Data
+    public static class Raw{
+        private Integer msgSeq;
+    }
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/message/MessageEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/message/MessageEvent.java
@@ -44,8 +44,22 @@ public class MessageEvent extends Event {
     @JSONField(name = "raw")
     private Raw raw;
 
+
+    /**
+     * Raw字段在napcat开启debug模式时会出现，其中有msgSeq字段。
+     * 在单个群聊内，不同bot，收到同一条消息时，msgSeq是相同的，
+     * 基于此可以实现群聊内多bot的均衡负载。
+     *
+     * raw内还有更多数据...
+     */
     @Data
     public static class Raw{
+        private Long msgId;
+        private Long msgRandom;
         private Integer msgSeq;
+        private Integer chatType;
+        private Integer msgType;
+        private Integer subMsgType;
+        private Integer sendType;
     }
 }


### PR DESCRIPTION
raw字段在协议端使用napcat并开启debug模式时会出现，raw内有msgSeq字段。
在单个群聊内，不同bot，收到同一条消息时，msgSeq是相同的，
基于此可以实现群聊内多bot的均衡负载。

使用messageEvent.getRaw().getMsgSeq();获取MsgSeq字段