### PR TITLE
feat:make shiro able to load plugin.jar

### DIFF
--- a/src/main/java/com/mikuac/shiro/common/utils/EventUtils.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/EventUtils.java
@@ -43,9 +43,10 @@ public class EventUtils {
      */
     public BotPlugin getPlugin(Class<? extends BotPlugin> pluginClass) {
         try {
+            // 直接获取已注册的单例Bean
             return ctx.getBean(pluginClass);
         } catch (Exception e) {
-            log.warn("Plugin {} is skipped. Please check the @Component annotation.", pluginClass.getSimpleName());
+            log.error("Plugin {} load failed: {}", pluginClass.getSimpleName(), e.getMessage());
             return defaultPlugin;
         }
     }

--- a/src/main/java/com/mikuac/shiro/properties/ShiroProperties.java
+++ b/src/main/java/com/mikuac/shiro/properties/ShiroProperties.java
@@ -3,12 +3,19 @@ package com.mikuac.shiro.properties;
 import com.mikuac.shiro.core.BotMessageEventInterceptor;
 import com.mikuac.shiro.core.BotPlugin;
 import com.mikuac.shiro.core.DefaultBotMessageEventInterceptor;
+import jakarta.annotation.PostConstruct;
 import lombok.Data;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Created on 2021/8/12.
@@ -21,10 +28,17 @@ import java.util.List;
 @ConfigurationProperties(prefix = "shiro")
 public class ShiroProperties {
 
-    /**
-     * 插件列表
-     */
-    private List<Class<? extends BotPlugin>> pluginList = new ArrayList<>();
+    // 修改插件列表为线程安全
+    private List<Class<? extends BotPlugin>> pluginList = new CopyOnWriteArrayList<>();
+    //插件扫描路径（默认：项目根目录下的plugins目录）
+    private String pluginScanPath = "plugins";
+
+
+    // 新增类加载器
+    private URLClassLoader pluginClassLoader;
+
+    @Autowired
+    private ApplicationContext applicationContext;
 
     /**
      * 拦截器
@@ -63,4 +77,48 @@ public class ShiroProperties {
      */
     private Boolean debug = false;
 
+    // 新增初始化方法
+    @PostConstruct
+    public void initPlugins() throws Exception {
+        File pluginDir = new File(pluginScanPath);
+        if (!pluginDir.exists() || !pluginDir.isDirectory()) {
+            return;
+        }
+
+        // 使用应用类加载器作为父加载器
+        ClassLoader parentLoader = applicationContext.getClassLoader();
+        List<URL> urls = new ArrayList<>();
+
+        for (File jar : Optional.ofNullable(pluginDir.listFiles((dir, name) -> name.endsWith(".jar")))
+                .orElse(new File[0])) {
+            urls.add(jar.toURI().toURL());
+        }
+
+        // 创建自定义类加载器
+        pluginClassLoader = new URLClassLoader(urls.toArray(new URL[0]), parentLoader) {
+            @Override
+            public Class<?> loadClass(String name) throws ClassNotFoundException {
+                try {
+                    return parentLoader.loadClass(name);
+                } catch (ClassNotFoundException e) {
+                    return super.loadClass(name);
+                }
+            }
+        };
+
+        ServiceLoader<BotPlugin> loader = ServiceLoader.load(BotPlugin.class, pluginClassLoader);
+        loader.forEach(plugin -> {
+            if (plugin.getClass().isAnnotationPresent(Component.class)) {
+
+                String beanName = plugin.getClass().getSimpleName().substring(0, 1).toLowerCase()
+                        + plugin.getClass().getSimpleName().substring(1);
+
+                ((DefaultListableBeanFactory) applicationContext.getAutowireCapableBeanFactory())
+                        .registerSingleton(beanName, plugin);
+
+                // 保持插件列表兼容性
+                pluginList.add(plugin.getClass());
+            }
+        });
+    }
 }


### PR DESCRIPTION
让shiro可以加载jar包形式的外部插件。

示例用法：
下载[shiro_plugin](https://github.com/sa-yi/shiro_plugin)，使用build打包成jar，把jar放在shiro运行目录的plugins目录下，shiro会在启动时加载plugins下的jar。

**jar内BotPlugin不需要在shiro:plugin-list中定义**

jar的优先级低于原项目，即：
若原项目和插件项目有相同代码：
```
@Override
public int onGroupMessage(Bot bot, GroupMessageEvent event) {
        String msg = event.getMessage();

        if(msg.equals("ping")){
            bot.sendGroupMsg(event.getGroupId(),"pong",false);
            return MESSAGE_BLOCK;
        }
}
```
此时发送ping，只有原项目会输出pong，jar内的onGroupMessage会被原项目的MESSAGE_BLOCK阻断