### PR TITLE
Feat/plugin resolver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ out/
 
 ### Mac ###
 .DS_Store
+
+dependencies/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,12 +36,24 @@ tasks.named<Jar>("jar") {
 }
 
 repositories {
+    maven { url =uri("https://maven.aliyun.com/repository/public/") }
     mavenCentral()
 }
 
 dependencies {
     api("com.alibaba.fastjson2:fastjson2:2.0.56")
     api("org.springframework.boot:spring-boot-starter-websocket")
+
+
+    api("org.apache.maven:maven-resolver-provider:3.9.6")
+    api("org.apache.maven.resolver:maven-resolver-connector-basic:1.9.18")
+    api("org.apache.maven.resolver:maven-resolver-transport-file:1.9.18")
+    api("org.apache.maven.resolver:maven-resolver-transport-http:1.9.18")
+    api("org.apache.maven.resolver:maven-resolver-impl:1.9.18")
+    api("org.apache.maven.resolver:maven-resolver-api:1.9.18")
+    api("org.apache.maven.resolver:maven-resolver-util:1.9.18")
+    api("org.apache.maven.resolver:maven-resolver-spi:1.9.18")
+
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     testImplementation("org.junit.jupiter:junit-jupiter:5.12.1")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/java/com/mikuac/shiro/core/plugin_loader/DependencyResolver.java
+++ b/src/main/java/com/mikuac/shiro/core/plugin_loader/DependencyResolver.java
@@ -53,7 +53,7 @@ public class DependencyResolver {
         this.mavenCentral = new RemoteRepository.Builder(
                 "central",
                 "default",
-                "https://repo1.maven.org/maven2/").build();
+                "https://maven.aliyun.com/repository/public").build();
     }
 
     private static RepositorySystem newRepositorySystem() {
@@ -75,12 +75,12 @@ public class DependencyResolver {
         request.setArtifact(artifact);
         request.setRepositories(Collections.singletonList(mavenCentral));
 
-        log.info("parsing artifact {} 从 {}", artifact, mavenCentral);
+        //log.info("parsing artifact {} from {}", artifact, mavenCentral);
 
         try {
             ArtifactResult result = repositorySystem.resolveArtifact(session, request);
-            log.info("successfully parsed artifact {} to file {} from repository {}",
-                    artifact, result.getArtifact().getFile(), result.getRepository());
+            /*log.info("successfully parsed artifact {} to file {} from repository {}",
+                    artifact, result.getArtifact().getFile(), result.getRepository());*/
             return result;
         } catch (ArtifactResolutionException e) {
             log.error("parsing artifact failed: {}", e.getMessage());
@@ -95,7 +95,7 @@ public class DependencyResolver {
 
         @Override
         public void transferInitiated(TransferEvent event) {
-            log.info("开始下载: {}", event.getResource().getResourceName());
+            log.info("Downloading: {}", event.getResource().getResourceName());
         }
 
         @Override
@@ -112,24 +112,24 @@ public class DependencyResolver {
                 int filledLength = (int) (progress * PROGRESS_BAR_WIDTH);
                 String progressBar = "[" + "=".repeat(filledLength) + " "
                         + " ".repeat(PROGRESS_BAR_WIDTH - filledLength) + "]";
-                System.out.printf("\r下载进度: %s %.2f%%", progressBar, progress * 100);
+                System.out.printf("\rDownloading: %s %.2f%%", progressBar, progress * 100);
             }
         }
 
         @Override
         public void transferCorrupted(TransferEvent event) {
-            log.error("传输损坏: {}", event.getException().getMessage());
+            log.error("Transferring broken: {}", event.getException().getMessage());
         }
 
         @Override
         public void transferSucceeded(TransferEvent event) {
             System.out.println(); // 换行
-            log.info("下载完成: {}", event.getResource().getResourceName());
+            log.info("Download finished: {}", event.getResource().getResourceName());
         }
 
         @Override
         public void transferFailed(TransferEvent event) {
-            log.error("下载失败: {}", event.getException().getMessage());
+            log.error("Download error: {}", event.getException().getMessage());
         }
     }
 }

--- a/src/main/java/com/mikuac/shiro/core/plugin_loader/DependencyResolver.java
+++ b/src/main/java/com/mikuac/shiro/core/plugin_loader/DependencyResolver.java
@@ -1,0 +1,135 @@
+package com.mikuac.shiro.core.plugin_loader;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
+import org.eclipse.aether.impl.DefaultServiceLocator;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
+import org.eclipse.aether.spi.connector.transport.TransporterFactory;
+import org.eclipse.aether.transfer.TransferEvent;
+import org.eclipse.aether.transfer.TransferListener;
+import org.eclipse.aether.transport.file.FileTransporterFactory;
+import org.eclipse.aether.transport.http.HttpTransporterFactory;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.Collections;
+
+@Slf4j
+public class DependencyResolver {
+
+    public static final File dependenciesDir = Paths.get("dependencies").toFile();
+    // public static final File
+    // dependenciesDir=Paths.get(System.getProperty("user.home"), ".m2",
+    // "repository").toFile()
+
+    private final RepositorySystem repositorySystem;
+    private final DefaultRepositorySystemSession session;
+    private final RemoteRepository mavenCentral;
+
+    public DependencyResolver() {
+        log.info("dependencyResolver initiating");
+        // 初始化 Repository System
+        this.repositorySystem = newRepositorySystem();
+
+        // 初始化 Session
+        this.session = MavenRepositorySystemUtils.newSession();
+        LocalRepository localRepo = new LocalRepository(
+                dependenciesDir);
+        session.setLocalRepositoryManager(
+                repositorySystem.newLocalRepositoryManager(session, localRepo));
+        // 添加 TransferListener 以显示进度条
+        session.setTransferListener(new ConsoleTransferListener());
+        // 配置 Maven 中央仓库
+        this.mavenCentral = new RemoteRepository.Builder(
+                "central",
+                "default",
+                "https://repo1.maven.org/maven2/").build();
+    }
+
+    private static RepositorySystem newRepositorySystem() {
+        DefaultServiceLocator locator = MavenRepositorySystemUtils.newServiceLocator();
+        locator.addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class);
+        locator.addService(TransporterFactory.class, FileTransporterFactory.class);
+        locator.addService(TransporterFactory.class, HttpTransporterFactory.class);
+        return locator.getService(RepositorySystem.class);
+    }
+
+    public static void main(String[] args) throws Exception {
+        DependencyResolver resolver = new DependencyResolver();
+        resolver.resolveDependency("org.apache.commons:commons-lang3:3.12.0");
+    }
+
+    public ArtifactResult resolveDependency(String coordinates) throws ArtifactResolutionException {
+        Artifact artifact = new DefaultArtifact(coordinates);
+        ArtifactRequest request = new ArtifactRequest();
+        request.setArtifact(artifact);
+        request.setRepositories(Collections.singletonList(mavenCentral));
+
+        log.info("parsing artifact {} 从 {}", artifact, mavenCentral);
+
+        try {
+            ArtifactResult result = repositorySystem.resolveArtifact(session, request);
+            log.info("successfully parsed artifact {} to file {} from repository {}",
+                    artifact, result.getArtifact().getFile(), result.getRepository());
+            return result;
+        } catch (ArtifactResolutionException e) {
+            log.error("parsing artifact failed: {}", e.getMessage());
+            throw e;
+        }
+    }
+
+    // 自定义 TransferListener 实现类
+    private static class ConsoleTransferListener implements TransferListener {
+
+        private static final int PROGRESS_BAR_WIDTH = 50;
+
+        @Override
+        public void transferInitiated(TransferEvent event) {
+            log.info("开始下载: {}", event.getResource().getResourceName());
+        }
+
+        @Override
+        public void transferStarted(TransferEvent event) {
+            // 不需要实现
+        }
+
+        @Override
+        public void transferProgressed(TransferEvent event) {
+            long contentLength = event.getResource().getContentLength();
+            long transferred = event.getTransferredBytes();
+            if (contentLength > 0) {
+                double progress = (double) transferred / contentLength;
+                int filledLength = (int) (progress * PROGRESS_BAR_WIDTH);
+                String progressBar = "[" + "=".repeat(filledLength) + " "
+                        + " ".repeat(PROGRESS_BAR_WIDTH - filledLength) + "]";
+                System.out.printf("\r下载进度: %s %.2f%%", progressBar, progress * 100);
+            }
+        }
+
+        @Override
+        public void transferCorrupted(TransferEvent event) {
+            log.error("传输损坏: {}", event.getException().getMessage());
+        }
+
+        @Override
+        public void transferSucceeded(TransferEvent event) {
+            System.out.println(); // 换行
+            log.info("下载完成: {}", event.getResource().getResourceName());
+        }
+
+        @Override
+        public void transferFailed(TransferEvent event) {
+            log.error("下载失败: {}", event.getException().getMessage());
+        }
+    }
+}


### PR DESCRIPTION
支持在Shiro主程序启动时下载jar形式的插件内所需的依赖并加载

对应的jar示例插件也有所更新[ShiroPlugin](https://github.com/sa-yi/shiro_plugin)
主要改变了build.gradle.kts，把所需的依赖打包进MF文件让Shiro主程序能够识别

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

添加了在 Shiro 主程序启动时，下载并加载 JAR 格式插件依赖项的支持。它解析插件 manifest 文件中指定的依赖项，如果缺少则下载它们，并将它们添加到插件的类加载器中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adds support for downloading and loading dependencies for plugins in JAR format when the Shiro main program starts. It resolves dependencies specified in the plugin's manifest file, downloads them if missing, and adds them to the plugin's classloader.

</details>