### PR TITLE
feat:extend Bot.sendForwardMsg

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,15 +53,15 @@ dependencies {
     api("com.alibaba.fastjson2:fastjson2:$fastjson")
     api("org.springframework.boot:spring-boot-starter-websocket")
 
-    implementation("org.apache.maven:maven-resolver-provider:$mavenResolverProvider")
+    api("org.apache.maven:maven-resolver-provider:$mavenResolverProvider")
 
-    implementation("org.apache.maven.resolver:maven-resolver-connector-basic:$mavenArtifactResolver")
-    implementation("org.apache.maven.resolver:maven-resolver-transport-file:$mavenArtifactResolver")
-    implementation("org.apache.maven.resolver:maven-resolver-transport-http:$mavenArtifactResolver")
-    implementation("org.apache.maven.resolver:maven-resolver-impl:$mavenArtifactResolver")
-    implementation("org.apache.maven.resolver:maven-resolver-api:$mavenArtifactResolver")
-    implementation("org.apache.maven.resolver:maven-resolver-util:$mavenArtifactResolver")
-    implementation("org.apache.maven.resolver:maven-resolver-spi:$mavenArtifactResolver")
+    api("org.apache.maven.resolver:maven-resolver-connector-basic:$mavenArtifactResolver")
+    api("org.apache.maven.resolver:maven-resolver-transport-file:$mavenArtifactResolver")
+    api("org.apache.maven.resolver:maven-resolver-transport-http:$mavenArtifactResolver")
+    api("org.apache.maven.resolver:maven-resolver-impl:$mavenArtifactResolver")
+    api("org.apache.maven.resolver:maven-resolver-api:$mavenArtifactResolver")
+    api("org.apache.maven.resolver:maven-resolver-util:$mavenArtifactResolver")
+    api("org.apache.maven.resolver:maven-resolver-spi:$mavenArtifactResolver")
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/java/com/mikuac/shiro/common/utils/ShiroUtils.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/ShiroUtils.java
@@ -332,6 +332,28 @@ public class ShiroUtils {
     }
 
     /**
+     * 生成自定义合并转发消息的单条内容
+     * @param uin 指定QQ号，用于头像的显示
+     * @param name 指定的显示的QQ昵称
+     * @param msg   消息内容
+     * @return 消息结构
+     * <p>使用 {@link com.mikuac.shiro.core.Bot#sendGroupForwardMsg(long, List, String, String, String, List)}和{@link com.mikuac.shiro.core.Bot#sendPrivateForwardMsg(long, List, String, String, String, List)}来发送生成后的聊天记录</p>
+     */
+    public static Map<String, Object> generateSingleMsg(long uin, String name, String msg) {
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("name", name);
+        data.put("uin", uin);
+        data.put("content", msg);
+
+        Map<String, Object> node = new HashMap<>();
+        node.put("type", "node");
+        node.put("data", data);
+
+        return node;
+    }
+
+    /**
      * 兼容 Lagrange
      * 生成自定义合并转发消息
      *

--- a/src/main/java/com/mikuac/shiro/constant/ActionParams.java
+++ b/src/main/java/com/mikuac/shiro/constant/ActionParams.java
@@ -99,4 +99,11 @@ public class ActionParams {
 
     public static final String IS_ADD = "is_add";
 
+    public static final String NEWS = "news";
+
+    public static final String PROMPT = "prompt";
+
+    public static final String SUMMARY = "summary";
+
+    public static final String SOURCE = "source";
 }

--- a/src/main/java/com/mikuac/shiro/core/Bot.java
+++ b/src/main/java/com/mikuac/shiro/core/Bot.java
@@ -1162,6 +1162,54 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
     }
 
     /**
+     * 发送群聊嵌套聊天记录
+     *
+     * @param groupId 为要发送的群聊
+     * @param msg     为消息记录
+     * @param prompt  为在外部消息列表显示的文字
+     * @param source  为顶部文本
+     * @param summary 为底部文本
+     * @param news    为外显的摘要消息，最多三条；内容的构建参考消息节点。一般来说key为text,value为文本内容
+     * <p>参考 {@link com.mikuac.shiro.common.utils.ShiroUtils#generateSingleMsg(long, String, String)}</p>来生成单条聊天记录
+     */
+    public ActionData<MsgId> sendGroupForwardMsg(long groupId, List<Map<String, Object>> msg, String prompt, String source, String summary, List<Map<String, String>> news) {
+        JSONObject params = new JSONObject();
+        params.put(ActionParams.GROUP_ID, groupId);
+        params.put(ActionParams.MESSAGES, msg);
+        params.put(ActionParams.NEWS, news);
+        params.put(ActionParams.PROMPT, prompt);
+        params.put(ActionParams.SOURCE, source);
+        params.put(ActionParams.SUMMARY, summary);
+        JSONObject result = actionHandler.action(session, ActionPathEnum.SEND_GROUP_FORWARD_MSG, params);
+        return result != null ? result.to(new TypeReference<ActionData<MsgId>>() {
+        }.getType()) : null;
+    }
+
+    /**发送私聊嵌套聊天记录
+     *
+     * @param userId 为要发送的用户
+     * @param msg     为消息记录
+     * @param prompt  为在外部消息列表显示的文字
+     * @param source  为顶部文本
+     * @param summary 为底部文本
+     * @param news    为外显的摘要消息，最多三条；内容的构建参考消息节点。一般来说key为text,value为文本内容
+     * <p>参考 {@link com.mikuac.shiro.common.utils.ShiroUtils#generateSingleMsg(long, String, String)}</p>来生成单条聊天记录
+     */
+    public ActionData<MsgId> sendPrivateForwardMsg(long userId, List<Map<String, Object>> msg, String prompt, String source, String summary, List<Map<String, String>> news) {
+        JSONObject params = new JSONObject();
+        params.put(ActionParams.USER_ID, userId);
+        params.put(ActionParams.MESSAGES, msg);
+        params.put(ActionParams.NEWS, news);
+        params.put(ActionParams.PROMPT, prompt);
+        params.put(ActionParams.SOURCE, source);
+        params.put(ActionParams.SUMMARY, summary);
+        JSONObject result = actionHandler.action(session, ActionPathEnum.SEND_PRIVATE_FORWARD_MSG, params);
+        return result != null ? result.to(new TypeReference<ActionData<MsgId>>() {
+        }.getType()) : null;
+    }
+
+
+    /**
      * 获取中文分词
      *
      * @param content 内容


### PR DESCRIPTION
扩展合并转发方法，支持自定义消息
（仅在协议端为napcat进行测试）

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

扩展机器人的消息转发功能，添加新方法以在群聊和私聊中发送自定义转发消息

**新功能：**

- 添加方法以发送自定义转发消息，并为群聊和私聊添加诸如 prompt、source、summary 和 news 等附加参数
- 引入一个实用方法来为转发消息生成单个消息节点

**增强功能：**

- 通过允许更详细地自定义转发消息结构来提高消息转发的灵活性

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend the bot's message forwarding capabilities by adding new methods for sending customized forward messages in group and private chats

New Features:
- Add methods to send customized forward messages with additional parameters like prompt, source, summary, and news for both group and private chats
- Introduce a utility method to generate single message nodes for forward messages

Enhancements:
- Improve message forwarding flexibility by allowing more detailed customization of forwarded message structures

</details>