### PR TITLE
添加功能：获取好友和群聊的历史消息

### DIFF
--- a/src/main/java/com/mikuac/shiro/action/NapCatExtend.java
+++ b/src/main/java/com/mikuac/shiro/action/NapCatExtend.java
@@ -1,0 +1,28 @@
+package com.mikuac.shiro.action;
+
+import com.mikuac.shiro.dto.action.common.ActionData;
+import com.mikuac.shiro.dto.action.response.GetMsgListResp;
+
+public interface NapCatExtend {
+
+    /**
+     * 获取群聊历史消息记录
+     * @param groupId 指定的群聊
+     * @param messageSeq 指定的消息id
+     * @param count 获取的消息条数
+     * @param reverseOrder 是否反转获取到的消息,false：返回的消息为正序；true:返回的消息为倒序
+     * @return 返回的消息列表
+     */
+    ActionData<GetMsgListResp> getGroupMsgHistory(long groupId, Long messageSeq, int count, boolean reverseOrder);
+
+    /**
+     * 获取好友历史消息记录
+     * @param userId 指定的好友
+     * @param messageSeq 指定的消息id
+     * @param count 获取的消息条数
+     * @param reverseOrder 是否反转获取到的消息,false：返回的消息为正序；true:返回的消息为倒序
+     * @return 返回的消息列表
+     */
+    ActionData<GetMsgListResp> getFriendMsgHistory(long userId,Long messageSeq,int count,boolean reverseOrder);
+
+}

--- a/src/main/java/com/mikuac/shiro/action/OneBot.java
+++ b/src/main/java/com/mikuac/shiro/action/OneBot.java
@@ -330,4 +330,24 @@ public interface OneBot {
      */
     ActionData<LoginInfoResp> getLoginInfo();
 
+    /**
+     * 获取群聊历史消息记录
+     * @param groupId 指定的群聊
+     * @param messageSeq 指定的消息id
+     * @param count 获取的消息条数
+     * @param reverseOrder 是否反转获取到的消息,false：返回的消息为正序；true:返回的消息为倒序
+     * @return 返回的消息列表
+     */
+    ActionData<GetMsgListResp> getGroupMsgHistory(long groupId,Long messageSeq,int count,boolean reverseOrder);
+
+    /**
+     * 获取好友历史消息记录
+     * @param userId 指定的好友
+     * @param messageSeq 指定的消息id
+     * @param count 获取的消息条数
+     * @param reverseOrder 是否反转获取到的消息,false：返回的消息为正序；true:返回的消息为倒序
+     * @return 返回的消息列表
+     */
+    ActionData<GetMsgListResp> getFriendMsgHistory(long userId,Long messageSeq,int count,boolean reverseOrder);
+
 }

--- a/src/main/java/com/mikuac/shiro/action/OneBot.java
+++ b/src/main/java/com/mikuac/shiro/action/OneBot.java
@@ -330,24 +330,4 @@ public interface OneBot {
      */
     ActionData<LoginInfoResp> getLoginInfo();
 
-    /**
-     * 获取群聊历史消息记录
-     * @param groupId 指定的群聊
-     * @param messageSeq 指定的消息id
-     * @param count 获取的消息条数
-     * @param reverseOrder 是否反转获取到的消息,false：返回的消息为正序；true:返回的消息为倒序
-     * @return 返回的消息列表
-     */
-    ActionData<GetMsgListResp> getGroupMsgHistory(long groupId,Long messageSeq,int count,boolean reverseOrder);
-
-    /**
-     * 获取好友历史消息记录
-     * @param userId 指定的好友
-     * @param messageSeq 指定的消息id
-     * @param count 获取的消息条数
-     * @param reverseOrder 是否反转获取到的消息,false：返回的消息为正序；true:返回的消息为倒序
-     * @return 返回的消息列表
-     */
-    ActionData<GetMsgListResp> getFriendMsgHistory(long userId,Long messageSeq,int count,boolean reverseOrder);
-
 }

--- a/src/main/java/com/mikuac/shiro/constant/ActionParams.java
+++ b/src/main/java/com/mikuac/shiro/constant/ActionParams.java
@@ -37,6 +37,12 @@ public class ActionParams {
 
     public static final String MESSAGE_ID = "message_id";
 
+    public static final String MESSAGE_SEQ = "message_seq";
+
+    public static final String COUNT = "count";
+
+    public static final String REVERSE_ORDER = "reverseOrder";
+
     public static final String GUILD_ID = "guild_id";
 
     public static final String NEXT_TOKEN = "next_token";

--- a/src/main/java/com/mikuac/shiro/core/Bot.java
+++ b/src/main/java/com/mikuac/shiro/core/Bot.java
@@ -32,7 +32,7 @@ import java.util.Map;
 @Getter
 @Setter
 @SuppressWarnings({"unused", "Duplicates"})
-public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExtend, LLOneBotExtend {
+public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExtend, LLOneBotExtend, NapCatExtend {
 
     private long selfId;
 

--- a/src/main/java/com/mikuac/shiro/core/Bot.java
+++ b/src/main/java/com/mikuac/shiro/core/Bot.java
@@ -1457,6 +1457,46 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
     }
 
     /**
+     * 获取群聊历史消息记录
+     * @param groupId 指定的群聊
+     * @param messageSeq 指定的消息id
+     * @param count 获取的消息条数
+     * @param reverseOrder 是否反转获取到的消息,false：返回的消息为正序；true:返回的消息为倒序
+     * @return 返回的消息列表
+     */
+
+    @Override
+    public ActionData<GetMsgListResp> getGroupMsgHistory(long groupId,Long messageSeq,int count,boolean reverseOrder){
+        JSONObject params = new JSONObject();
+        params.put(ActionParams.GROUP_ID,groupId);
+        if(messageSeq!=null) params.put(ActionParams.MESSAGE_SEQ,messageSeq);
+        params.put(ActionParams.COUNT,count);
+        params.put(ActionParams.REVERSE_ORDER,reverseOrder);
+        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_GROUP_MSG_HISTORY,params);
+        return result != null ? result.to(new TypeReference<ActionData<GetMsgListResp>>() {
+        }.getType()) : null;
+    }
+    /**
+     * 获取好友历史消息记录
+     * @param userId 指定的好友
+     * @param messageSeq 指定的消息id
+     * @param count 获取的消息条数
+     * @param reverseOrder 是否反转获取到的消息,false：返回的消息为正序；true:返回的消息为倒序
+     * @return 返回的消息列表
+     */
+    @Override
+    public ActionData<GetMsgListResp> getFriendMsgHistory(long userId,Long messageSeq,int count,boolean reverseOrder){
+        JSONObject params = new JSONObject();
+        params.put(ActionParams.USER_ID,userId);
+        if(messageSeq!=null) params.put(ActionParams.MESSAGE_SEQ,messageSeq);
+        params.put(ActionParams.COUNT,count);
+        params.put(ActionParams.REVERSE_ORDER,reverseOrder);
+        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_FRIEND_MSG_HISTORY,params);
+        return result != null ? result.to(new TypeReference<ActionData<GetMsgListResp>>() {
+        }.getType()) : null;
+    }
+
+    /**
      * 设置群消息表情回应
      *
      * @param groupId 群号

--- a/src/main/java/com/mikuac/shiro/dto/action/response/GetMsgListResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/GetMsgListResp.java
@@ -1,0 +1,12 @@
+package com.mikuac.shiro.dto.action.response;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class GetMsgListResp {
+    private String status;
+    private int retcode;
+    private List<GetMsgResp> messages;
+}

--- a/src/main/java/com/mikuac/shiro/enums/ActionPathEnum.java
+++ b/src/main/java/com/mikuac/shiro/enums/ActionPathEnum.java
@@ -62,6 +62,16 @@ public enum ActionPathEnum implements ActionPath {
      * 设置群组专属头衔
      */
     SET_GROUP_SPECIAL_TITLE("set_group_special_title"),
+
+    /**
+     * 获取群聊历史消息
+     */
+    GET_GROUP_MSG_HISTORY("get_group_msg_history"),
+
+    /**
+     * 获取群聊历史消息
+     */
+    GET_FRIEND_MSG_HISTORY("get_friend_msg_history"),
     /**
      * 处理加好友请求
      */


### PR DESCRIPTION
## Sourcery 总结

在 OneBot API 实现中添加了检索群组和好友历史消息的方法

新特性：
- 实现了获取群聊历史消息的方法
- 实现了获取好友历史消息的方法

增强功能：
- 使用新的消息检索功能扩展了 OneBot 接口
- 为消息历史记录检索添加了新的操作路径
- 创建了一个响应 DTO 来处理消息列表响应

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add methods to retrieve historical messages for groups and friends in the OneBot API implementation

New Features:
- Implement methods to fetch historical messages for group chats
- Implement methods to fetch historical messages for individual friends

Enhancements:
- Extend the OneBot interface with new message retrieval capabilities
- Add new action paths for message history retrieval
- Create a response DTO to handle message list responses

</details>