### PR TITLE
修复了MESSAGE_SEQ的字段错误

### DIFF
--- a/src/main/java/com/mikuac/shiro/constant/ActionParams.java
+++ b/src/main/java/com/mikuac/shiro/constant/ActionParams.java
@@ -37,7 +37,7 @@ public class ActionParams {
 
     public static final String MESSAGE_ID = "message_id";
 
-    public static final String MESSAGE_SEQ = "message_seq";
+    public static final String MESSAGE_SEQ = "messageSeq";
 
     public static final String COUNT = "count";
 


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复：
- 修正了 `MESSAGE_SEQ` 常量的值，从 `"message_seq"` 改为 `"messageSeq"`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the MESSAGE_SEQ constant value from "message_seq" to "messageSeq"

</details>