### PR TITLE
添加群聊和好友戳一戳(napcat协议端)

### DIFF
--- a/src/main/java/com/mikuac/shiro/action/NapCatExtend.java
+++ b/src/main/java/com/mikuac/shiro/action/NapCatExtend.java
@@ -1,6 +1,7 @@
 package com.mikuac.shiro.action;
 
 import com.mikuac.shiro.dto.action.common.ActionData;
+import com.mikuac.shiro.dto.action.common.ActionRaw;
 import com.mikuac.shiro.dto.action.response.GetMsgListResp;
 
 public interface NapCatExtend {
@@ -27,4 +28,9 @@ public interface NapCatExtend {
      */
     ActionData<GetMsgListResp> getFriendMsgHistory(long userId, Long messageSeq, int count, boolean reverseOrder);
 
+    ActionRaw sendGroupPoke(long groupId,long userId);
+
+    ActionRaw sendFriendPoke(long userId);
+
+    ActionRaw sendFriendPoke(long userId,long targetId);
 }

--- a/src/main/java/com/mikuac/shiro/constant/ActionParams.java
+++ b/src/main/java/com/mikuac/shiro/constant/ActionParams.java
@@ -7,6 +7,8 @@ public class ActionParams {
 
     public static final String USER_ID = "user_id";
 
+    public static final String TARGET_ID = "target_id";
+
     public static final String MESSAGE = "message";
 
     public static final String AUTO_ESCAPE = "auto_escape";

--- a/src/main/java/com/mikuac/shiro/core/Bot.java
+++ b/src/main/java/com/mikuac/shiro/core/Bot.java
@@ -1513,6 +1513,33 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
         }.getType()) : null;
     }
 
+
+    @Override
+    public ActionRaw sendFriendPoke(long userId) {
+        JSONObject params = new JSONObject();
+        params.put(ActionParams.USER_ID, userId);
+        JSONObject result = actionHandler.action(session, ActionPathEnum.FRIEND_POKE, params);
+        return result != null ? result.to(ActionRaw.class) : null;
+    }
+
+    @Override
+    public ActionRaw sendFriendPoke(long userId,long targetId) {
+        JSONObject params = new JSONObject();
+        params.put(ActionParams.USER_ID, userId);
+        params.put(ActionParams.TARGET_ID,targetId);
+        JSONObject result = actionHandler.action(session, ActionPathEnum.FRIEND_POKE, params);
+        return result != null ? result.to(ActionRaw.class) : null;
+    }
+
+    @Override
+    public ActionRaw sendGroupPoke(long groupId, long userId) {
+        JSONObject params = new JSONObject();
+        params.put(ActionParams.USER_ID, userId);
+        params.put(ActionParams.GROUP_ID, groupId);
+        JSONObject result = actionHandler.action(session, ActionPathEnum.GROUP_POKE, params);
+        return result != null ? result.to(ActionRaw.class) : null;
+    }
+
     /**
      * 设置群消息表情回应
      *

--- a/src/main/java/com/mikuac/shiro/dto/action/response/GroupInfoExResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/GroupInfoExResp.java
@@ -1,0 +1,71 @@
+package com.mikuac.shiro.dto.action.response;
+
+
+import com.alibaba.fastjson2.annotation.JSONField;
+import lombok.Data;
+
+
+@Data
+public class GroupInfoExResp {
+    @JSONField(name = "groupCode")
+    private long groupCode;//群号
+    @JSONField(name = "resultCode")
+    private long resultCode;//结果码
+    @JSONField(name = "extInfo")
+    private ExtInfo extInfo;//扩展信息
+
+    @Data
+    public static class ExtInfo {
+        @JSONField(name = "groupInfoExtSeq")
+        private long groupInfoExtSeq;//群信息序列号
+        @JSONField(name = "reserve")
+        private int reserve;//?
+        @JSONField(name = "luckyWordId")
+        private int luckyWordId;//幸运字符ID
+        @JSONField(name = "lightCharNum")
+        private int lightCharNum;//?
+        @JSONField(name = "luckyWord")
+        private String luckyWord;//幸运字符
+        @JSONField(name = "starId")
+        private long starId;//?
+        @JSONField(name = "essentialMsgSwitch")
+        private int essentialMsgSwitch;//精华消息开关
+        @JSONField(name = "todoSeq")
+        private long todoSeq;//?
+        @JSONField(name = "blacklistExpireTime")
+        private long blacklistExpireTime;//黑名单过期时间
+        @JSONField(name = "isLimitGroupRtc")
+        private int isLimitGroupRtc;//是否限制群视频通话
+        @JSONField(name = "companyId")
+        private long companyId;//公司ID
+        @JSONField(name = "hasGroupCustomPortrait")
+        private int hasGroupCustomPortrait;//是否有群自定义头像
+        @JSONField(name = "bindGuildId")
+        private long bindGuildId;//绑定频道ID？
+        @JSONField(name = "groupOwnerId")
+        private GroupOwner groupOwnerId;//群主信息
+        @JSONField(name = "essentialMsgPrivilege")
+        private int essentialMsgPrivilege;//精华消息权限
+        @JSONField(name = "msgEventSeq")
+        private String msgEventSeq;//消息事件序列号
+        @JSONField(name = "inviteRobotSwitch")
+        private int inviteRobotSwitch;//邀请机器人开关
+        @JSONField(name = "gangUpId")
+        private String gangUpId;//?
+        @JSONField(name = "qqMusicMedalSwitch")
+        private int qqMusicMedalSwitch;//QQ音乐勋章开关
+        @JSONField(name = "showPlayTogetherSwitch")
+        private int showPlayTogetherSwitch;//显示一起玩开关
+        @JSONField(name = "groupFlagPro1")
+        private String groupFlagPro1;//群标识1
+    }
+    @Data
+    public static class GroupOwner {
+        @JSONField(name = "memberUin")//QQ号
+        private long memberUin;
+        @JSONField(name = "memberUid")//UID
+        private String memberUid;
+        @JSONField(name = "memberQid")//QID
+        private String memberQid;
+    }
+}

--- a/src/main/java/com/mikuac/shiro/enums/ActionPathEnum.java
+++ b/src/main/java/com/mikuac/shiro/enums/ActionPathEnum.java
@@ -72,6 +72,16 @@ public enum ActionPathEnum implements ActionPath {
      * 获取群聊历史消息
      */
     GET_FRIEND_MSG_HISTORY("get_friend_msg_history"),
+
+    /**
+     * 发送好友戳一戳
+     */
+    FRIEND_POKE("friend_poke"),
+
+    /**
+     * 发送群聊戳一戳
+     */
+    GROUP_POKE("group_poke"),
     /**
      * 处理加好友请求
      */


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

在 NapCat 协议中实现好友和群聊戳一戳功能，通过添加相应的方法、操作路径和参数，并引入 GroupInfoExResp DTO 以获取扩展的群组信息。

新功能：
- 在 Bot 和 NapCatExtend 中添加 sendFriendPoke 和 sendGroupPoke 方法，用于好友和群聊戳一戳操作
- 在 ActionPathEnum 中注册 FRIEND_POKE 和 GROUP_POKE，并在 ActionParams 中引入 TARGET_ID 参数
- 添加 GroupInfoExResp DTO，用于扩展的群组元数据

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement friend and group poke functionality in the NapCat protocol by adding corresponding methods, action paths, and parameters, and introduce a GroupInfoExResp DTO for extended group information.

New Features:
- Add sendFriendPoke and sendGroupPoke methods to Bot and NapCatExtend for friend and group poke actions
- Register FRIEND_POKE and GROUP_POKE in ActionPathEnum and introduce TARGET_ID parameter in ActionParams
- Add GroupInfoExResp DTO for extended group metadata

</details>