### PR TITLE
fix: ActionHandler.action线程安全问题

### DIFF
--- a/src/main/java/com/mikuac/shiro/common/utils/PayloadSender.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/PayloadSender.java
@@ -33,7 +33,7 @@ public class PayloadSender {
 
     private JSONObject resp;
 
-    private final Lock lock = new ReentrantLock();
+    private static final Lock lock = new ReentrantLock();
 
     private final Condition condition = lock.newCondition();
 

--- a/src/main/java/com/mikuac/shiro/handler/ActionHandler.java
+++ b/src/main/java/com/mikuac/shiro/handler/ActionHandler.java
@@ -22,6 +22,7 @@ import org.springframework.web.socket.WebSocketSession;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Created on 2021/7/7.
@@ -56,7 +57,7 @@ public class ActionHandler {
     /**
      * 用于标识请求，可以是任何类型的数据，OneBot 将会在调用结果中原样返回
      */
-    private int echo = 0;
+    private final AtomicInteger echo = new AtomicInteger();
 
     @Autowired
     public ActionHandler(WebSocketProperties wsProp, RateLimiterProperties rateLimiterProps, RateLimiter rateLimiter) {
@@ -153,7 +154,7 @@ public class ActionHandler {
     private JSONObject generatePayload(ActionPath action, Map<String, Object> params) {
         JSONObject payload = new JSONObject();
         payload.put("action", action.getPath());
-        payload.put("echo", echo++);
+        payload.put("echo", echo.getAndAdd(1));
         if (params != null && !params.isEmpty()) {
             payload.put("params", params);
         }

--- a/src/main/java/com/mikuac/shiro/handler/ActionHandler.java
+++ b/src/main/java/com/mikuac/shiro/handler/ActionHandler.java
@@ -22,6 +22,7 @@ import org.springframework.web.socket.WebSocketSession;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -37,7 +38,7 @@ public class ActionHandler {
     /**
      * 请求回调数据
      */
-    private final Map<String, PayloadSender> callback = new HashMap<>();
+    private final Map<String, PayloadSender> callback = new ConcurrentHashMap<>();
 
     /**
      * WebSocket 配置

--- a/src/main/java/com/mikuac/shiro/handler/ActionHandler.java
+++ b/src/main/java/com/mikuac/shiro/handler/ActionHandler.java
@@ -155,7 +155,7 @@ public class ActionHandler {
     private JSONObject generatePayload(ActionPath action, Map<String, Object> params) {
         JSONObject payload = new JSONObject();
         payload.put("action", action.getPath());
-        payload.put("echo", echo.getAndAdd(1));
+        payload.put("echo", echo.getAndIncrement());
         if (params != null && !params.isEmpty()) {
             payload.put("params", params);
         }


### PR DESCRIPTION
ActionHandler.action多线程下会出现线程安全问题，返回错误响应retCode=-1。
<img width="1112" height="291" alt="image" src="https://github.com/user-attachments/assets/620bba53-0f46-4ed5-9054-d7d1a59a6dd2" />
### **原因**：
- 1. 每次调用ActionHandler.action会创建一个新的PayloadSender，而PayloadSender中锁对象非静态，不同PayloadSender对象会持有不同锁，导致无效上锁。
<img width="937" height="146" alt="image" src="https://github.com/user-attachments/assets/5736e992-8235-49fa-940f-ea78e944a8fe" />
<img width="582" height="46" alt="image" src="https://github.com/user-attachments/assets/cab1323d-109e-4028-a4a7-2e1e1586f466" />

- 2. ActionHandler.callback中key由int类型的echo++获得，而多线程下echo++操作会有线程安全问题，导致多个回调相互覆盖。

### **效果**：
修改前：
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/99cbf9c9-bff4-4687-85ef-b028b825c33d" />

修改后：
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/72a5e289-2598-4a3f-986c-dc5f68c76cac" />

### 测试代码：
```
@Slf4j
@SpringBootApplication
public class ShiroTestApplication implements ApplicationRunner {
    @Autowired
    private BotContainer container;

    @Override
    public void run(ApplicationArguments args) {
        int des = 10;
        AtomicInteger count = new AtomicInteger(0);
        container.robots.forEach((key, bot) -> {
            Runnable friendListRunnable = () -> {
                ActionList<FriendInfoResp> list = bot.getFriendList();
                int i = count.addAndGet(1);
                if (i == des * 2) {
                    log.info("测试结束");
                }
                if (list == null) {
                    log.warn("timeout-{}", i);
                    return;
                }
                if (list.getData() == null) {
                    log.error("fail-{}: 获取好友列表失败", i);
                } else {
                    log.info("success-{}: 好友列表长度为{}", i, list.getData().size());
                }

            };
            Runnable groupListRunnable = () -> {
                ActionList<GroupInfoResp> list = bot.getGroupList();
                int i = count.addAndGet(1);
                if (i == des * 2) {
                    log.info("测试结束");
                }
                if (list == null) {
                    log.warn("timeout-{}", i);
                    return;
                }
                if (list.getData() == null) {
                    log.error("fail-{}: 获取群组列表失败", i);
                } else {
                    log.info("success-{}: 群组列表长度为{}", i, list.getData().size());
                }
            };

            for (int i = 0; i < des; i++) {
                new Thread(friendListRunnable).start();
                new Thread(groupListRunnable).start();
            }
        });
    }

    public static void main(String[] args) {
        SpringApplication.run(ShiroTestApplication.class, args);
    }

}

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

通过将非原子回显计数器替换为 AtomicInteger 并将 PayloadSender 中的锁合并到静态实例，确保 ActionHandler.action 是线程安全的。

Bug 修复：
- 将整数回显字段替换为 AtomicInteger，以便在有效负载生成中进行原子回显递增
- 将 PayloadSender 锁更改为 static final，以便所有实例共享一个锁

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure ActionHandler.action is thread-safe by replacing the non-atomic echo counter with AtomicInteger and consolidating the lock in PayloadSender to a static instance.

Bug Fixes:
- Replace integer echo field with AtomicInteger for atomic echo increments in payload generation
- Change PayloadSender lock to static final so all instances share a single lock

</details>