### PR TITLE
整理 jackson 一些序列化的问题

### DIFF
--- a/src/main/java/com/mikuac/shiro/adapter/WebSocketServerHandler.java
+++ b/src/main/java/com/mikuac/shiro/adapter/WebSocketServerHandler.java
@@ -73,6 +73,8 @@ public class WebSocketServerHandler extends TextWebSocketHandler {
     @Override
     public void afterConnectionEstablished(@NonNull WebSocketSession session) {
         try {
+            session.setTextMessageSizeLimit(wsProp.getMaxTextMessageBufferSize());
+            session.setBinaryMessageSizeLimit(wsProp.getMaxBinaryMessageBufferSize());
             session.getAttributes().put(Connection.ADAPTER_KEY, AdapterEnum.SERVER);
             long xSelfId = ConnectionUtils.parseSelfId(session);
             if (xSelfId == 0L) {
@@ -91,7 +93,6 @@ public class WebSocketServerHandler extends TextWebSocketHandler {
             }
             var sessionContext = session.getAttributes();
             sessionContext.put(Connection.SESSION_STATUS_KEY, SessionStatusEnum.ONLINE);
-
             if (shiroProps.getWaitBotConnect() <= 0) {
                 if (botContainer.robots.containsKey(xSelfId)) {
                     log.info("Bot {} already connected with another instance", xSelfId);

--- a/src/main/java/com/mikuac/shiro/common/utils/CommonUtils.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/CommonUtils.java
@@ -37,11 +37,11 @@ public class CommonUtils {
         Optional<ArrayMsg> opt = Optional.ofNullable(atParse(arrayMsg, selfId));
         return switch (at) {
             case NEED -> opt.map(item -> {
-                long target = Long.parseLong(item.getData().get("qq"));
+                long target = item.getLongData("qq");
                 return target == 0L || target != selfId;
             }).orElse(true);
             case NOT_NEED -> opt.map(item -> {
-                long target = Long.parseLong(item.getData().get("qq"));
+                long target = item.getLongData("qq");
                 return target == selfId;
             }).orElse(false);
             default -> false;
@@ -88,8 +88,8 @@ public class CommonUtils {
                 case OFF -> throw new ShiroException("exception that cannot be thrown");
                 case NONE -> reply.isEmpty();
                 case REPLY_ALL -> reply.isPresent();
-                case REPLY_ME -> reply.map(e -> e.getData().get("qq").equals(String.valueOf(selfId))).orElse(false);
-                case REPLY_OTHER -> reply.map(e -> !e.getData().get("qq").equals(String.valueOf(selfId))).orElse(false);
+                case REPLY_ME -> reply.map(e -> e.getLongData("qq") == selfId).orElse(false);
+                case REPLY_OTHER -> reply.map(e -> e.getLongData("qq") != selfId).orElse(false);
             };
             if (!flag) return new CheckResult();
         }
@@ -186,8 +186,7 @@ public class CommonUtils {
         }
         int index = 0;
         ArrayMsg item = arrayMsg.get(index);
-        String rawTarget = item.getData().getOrDefault("qq", "0");
-        long target = Long.parseLong(CommonEnum.AT_ALL.value().equals(rawTarget) ? "0" : rawTarget);
+        long target = item.getLongData("qq");
         index = arrayMsg.size() - 1;
         if ((target == 0L || target != selfId) && index >= 0) {
             item = arrayMsg.get(index);
@@ -196,8 +195,7 @@ public class CommonUtils {
             if (MsgTypeEnum.text == item.getType() && index >= 0) {
                 item = arrayMsg.get(index);
             }
-            rawTarget = item.getData().getOrDefault("qq", "0");
-            target = Long.parseLong(CommonEnum.AT_ALL.value().equals(rawTarget) ? "0" : rawTarget);
+            target = item.getLongData("qq");
             if (target == 0L || target != selfId) {
                 return null;
             }

--- a/src/main/java/com/mikuac/shiro/common/utils/JsonUtils.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/JsonUtils.java
@@ -63,6 +63,17 @@ public class JsonUtils {
         }
     }
 
+    public static <T> List<T> parseArray(JsonNode json, Class<T> clazz) {
+        try {
+            ObjectMapper mapper = getObjectMapper();
+            return mapper.convertValue(json,
+                    mapper.getTypeFactory().constructCollectionType(List.class, clazz));
+        } catch (IllegalArgumentException e) {
+            log.error("Failed to parse JSON array: {}", e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+
     @Nullable
     public static String toJSONString(Object object) {
         try {
@@ -101,4 +112,17 @@ public class JsonUtils {
         }
     }
 
+    public static String nodeToString(JsonNode node) {
+        if (node == null) {
+            return "";
+        }
+        if (node.isTextual()) {
+            return node.textValue();
+        }
+        try {
+            return getObjectMapper().writeValueAsString(node);
+        } catch (JsonProcessingException e) {
+            return node.toString();
+        }
+    }
 } 

--- a/src/main/java/com/mikuac/shiro/common/utils/MessageConverser.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/MessageConverser.java
@@ -24,7 +24,7 @@ public class MessageConverser {
             if (!MsgTypeEnum.text.equals(item.getType())) {
                 builder.append(item.toCQCode());
             } else {
-                builder.append(ShiroUtils.escape(item.getStringData(MsgTypeEnum.text.toString())));
+                builder.append(item.getStringData(MsgTypeEnum.text.toString()));
             }
         }
         return builder.toString();
@@ -149,11 +149,4 @@ public class MessageConverser {
         item.setData(data);
         chain.add(item);
     }
-
-    public static void convert(@NonNull String msg, MessageEvent event) {
-        if (CollectionUtils.isEmpty(event.getArrayMsg())) {
-            event.setArrayMsg(stringToArray(msg));
-        }
-    }
-
 }

--- a/src/main/java/com/mikuac/shiro/common/utils/MessageConverser.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/MessageConverser.java
@@ -1,9 +1,11 @@
 package com.mikuac.shiro.common.utils;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.mikuac.shiro.dto.event.message.MessageEvent;
 import com.mikuac.shiro.enums.MsgTypeEnum;
 import com.mikuac.shiro.model.ArrayMsg;
 import lombok.NonNull;
+import org.springframework.util.CollectionUtils;
 
 import java.util.*;
 
@@ -13,27 +15,16 @@ public class MessageConverser {
     }
 
     public static String arrayToString(ArrayMsg arrayMsg) {
-        StringBuilder builder = new StringBuilder();
-        if (Objects.isNull(arrayMsg.getType()) || MsgTypeEnum.unknown.equals(arrayMsg.getType())) {
-            builder.append("[CQ:").append(MsgTypeEnum.unknown);
-        } else {
-            builder.append("[CQ:").append(arrayMsg.getType());
-        }
-        arrayMsg.getData().forEach((k, v) -> builder.append(",").append(k).append("=").append(ShiroUtils.escape(v)));
-        builder.append("]");
-        return builder.toString();
+        return arrayMsg.toCQCode();
     }
 
     public static String arraysToString(List<ArrayMsg> array) {
         StringBuilder builder = new StringBuilder();
         for (ArrayMsg item : array) {
             if (!MsgTypeEnum.text.equals(item.getType())) {
-                builder.append("[CQ:").append(item.getType());
-                // message 字段转回 CQ 码的时候不要转义，raw_message 会保留原始内容。
-                item.getData().forEach((k, v) -> builder.append(",").append(k).append("=").append(v));
-                builder.append("]");
+                builder.append(item.toCQCode());
             } else {
-                builder.append(ShiroUtils.escape(item.getData().get(MsgTypeEnum.text.toString())));
+                builder.append(ShiroUtils.escape(item.getStringData(MsgTypeEnum.text.toString())));
             }
         }
         return builder.toString();
@@ -144,8 +135,9 @@ public class MessageConverser {
         // 检查最后一个消息是否为文本类型，如果是则合并
         if (!chain.isEmpty()) {
             ArrayMsg lastMsg = chain.get(chain.size() - 1);
-            if (lastMsg.getType() == MsgTypeEnum.text) {
-                lastMsg.getData().compute("text", (k, existingText) -> existingText + ShiroUtils.unescape(text));
+            if (lastMsg.getType() == MsgTypeEnum.text && lastMsg.getData().isObject()) {
+                ObjectNode obj = (ObjectNode) lastMsg.getData();
+                obj.put("text", obj.get("text").asText("") + ShiroUtils.unescape(text));
                 return;
             }
         }
@@ -159,16 +151,9 @@ public class MessageConverser {
     }
 
     public static void convert(@NonNull String msg, MessageEvent event) {
-        // 如果 msg 是一个有效的 json 数组则作为 array 上报
-        if (JsonUtils.isValidArray(msg)) {
-            List<ArrayMsg> arrayMsg = JsonUtils.parseArray(msg, ArrayMsg.class);
-            // 将 array 转换回 string
-            event.setArrayMsg(arrayMsg);
-            event.setMessage(arraysToString(arrayMsg));
-            return;
+        if (CollectionUtils.isEmpty(event.getArrayMsg())) {
+            event.setArrayMsg(stringToArray(msg));
         }
-        // string 上报
-        event.setArrayMsg(stringToArray(msg));
     }
 
 }

--- a/src/main/java/com/mikuac/shiro/common/utils/ShiroUtils.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/ShiroUtils.java
@@ -38,7 +38,7 @@ public class ShiroUtils {
      * @return 是否为全体at
      */
     public static boolean isAtAll(List<ArrayMsg> arrayMsg) {
-        return arrayMsg.stream().anyMatch(it -> "all".equals(it.getData().get("qq")));
+        return arrayMsg.stream().anyMatch(it -> it.getType().equals(MsgTypeEnum.at) && it.getLongData("qq") == 0L);
     }
 
     /**
@@ -50,8 +50,8 @@ public class ShiroUtils {
     public static List<Long> getAtList(List<ArrayMsg> arrayMsg) {
         return arrayMsg
                 .stream()
-                .filter(it -> MsgTypeEnum.at == it.getType() && !"all".equals(it.getData().get("qq")))
-                .map(it -> Long.parseLong(it.getData().get("qq")))
+                .filter(it -> MsgTypeEnum.at == it.getType() && it.getLongData("qq") != 0L)
+                .map(it -> it.getLongData("qq"))
                 .toList();
     }
 
@@ -64,7 +64,8 @@ public class ShiroUtils {
     public static List<String> getMsgImgUrlList(List<ArrayMsg> arrayMsg) {
         return arrayMsg
                 .stream()
-                .filter(it -> MsgTypeEnum.image == it.getType()).map(it -> it.getData().get("url"))
+                .filter(it -> MsgTypeEnum.image == it.getType())
+                .map(it -> it.getStringData("url"))
                 .toList();
     }
 
@@ -77,7 +78,8 @@ public class ShiroUtils {
     public static List<String> getMsgVideoUrlList(List<ArrayMsg> arrayMsg) {
         return arrayMsg
                 .stream()
-                .filter(it -> MsgTypeEnum.video == it.getType()).map(it -> it.getData().get("url"))
+                .filter(it -> MsgTypeEnum.video == it.getType())
+                .map(it -> it.getStringData("url"))
                 .toList();
     }
 

--- a/src/main/java/com/mikuac/shiro/dto/event/message/MessageEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/message/MessageEvent.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.mikuac.shiro.common.utils.JsonUtils;
+import com.mikuac.shiro.common.utils.MessageConverser;
 import com.mikuac.shiro.dto.event.Event;
 import com.mikuac.shiro.model.ArrayMsg;
 import lombok.AllArgsConstructor;
@@ -13,6 +14,8 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 
@@ -35,6 +38,7 @@ public class MessageEvent extends Event {
     @JsonProperty("user_id")
     private Long userId;
 
+    @JsonIgnore
     private String message;
 
     @JsonProperty("raw_message")
@@ -53,15 +57,26 @@ public class MessageEvent extends Event {
     private void setMessageFromJson(JsonNode json) {
         if (json.isTextual()) {
             this.message = json.asText();
+            this.arrayMsg = MessageConverser.stringToArray(message);
         } else if (json.isArray()) {
             this.arrayMsg = JsonUtils.parseArray(json, ArrayMsg.class);
-            message = JsonUtils.toJSONString(json);
+            message = MessageConverser.arraysToString(this.arrayMsg);
         } else {
             throw new IllegalArgumentException("Invalid message format: " + json);
         }
     }
+
+    @JsonIgnore
+    public void setMessage(String message) {
+        this.message = message;
+        this.arrayMsg = MessageConverser.stringToArray(message);
+    }
+
     @JsonGetter("message")
     public String getMessage() {
+        if (!StringUtils.hasText(message) && !CollectionUtils.isEmpty(arrayMsg)) {
+            message = MessageConverser.arraysToString(arrayMsg);
+        }
         return message;
     }
 
@@ -74,8 +89,8 @@ public class MessageEvent extends Event {
      */
     @Data
     public static class Raw {
-        private Long msgId;
-        private Long msgRandom;
+        private Long    msgId;
+        private Long    msgRandom;
         private Integer msgSeq;
         private Integer chatType;
         private Integer msgType;

--- a/src/main/java/com/mikuac/shiro/dto/event/message/MessageEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/message/MessageEvent.java
@@ -1,6 +1,11 @@
 package com.mikuac.shiro.dto.event.message;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.mikuac.shiro.common.utils.JsonUtils;
 import com.mikuac.shiro.dto.event.Event;
 import com.mikuac.shiro.model.ArrayMsg;
 import lombok.AllArgsConstructor;
@@ -30,7 +35,6 @@ public class MessageEvent extends Event {
     @JsonProperty("user_id")
     private Long userId;
 
-    @JsonProperty("message")
     private String message;
 
     @JsonProperty("raw_message")
@@ -39,10 +43,27 @@ public class MessageEvent extends Event {
     @JsonProperty("font")
     private Integer font;
 
+    @JsonIgnore
     private List<ArrayMsg> arrayMsg;
 
     @JsonProperty("raw")
     private Raw raw;
+
+    @JsonSetter("message")
+    private void setMessageFromJson(JsonNode json) {
+        if (json.isTextual()) {
+            this.message = json.asText();
+        } else if (json.isArray()) {
+            this.arrayMsg = JsonUtils.parseArray(json, ArrayMsg.class);
+            message = JsonUtils.toJSONString(json);
+        } else {
+            throw new IllegalArgumentException("Invalid message format: " + json);
+        }
+    }
+    @JsonGetter("message")
+    public String getMessage() {
+        return message;
+    }
 
     /**
      * Raw字段在napcat开启debug模式时会出现，其中有msgSeq字段。

--- a/src/main/java/com/mikuac/shiro/handler/ActionHandler.java
+++ b/src/main/java/com/mikuac/shiro/handler/ActionHandler.java
@@ -174,7 +174,7 @@ public class ActionHandler {
 
         List<Object> modified = original.stream().map(v -> {
             if (v instanceof ArrayMsg arrayMsg && arrayMsg.getType() == MsgTypeEnum.keyboard) {
-                String data = arrayMsg.getData().get("keyboard");
+                String data = arrayMsg.getStringData("keyboard");
                 return JsonUtils.parseObject(data);
             }
             return v;

--- a/src/main/java/com/mikuac/shiro/handler/event/MessageEvent.java
+++ b/src/main/java/com/mikuac/shiro/handler/event/MessageEvent.java
@@ -75,7 +75,7 @@ public class MessageEvent {
                 if (utils.setInterceptor(bot, event)) {
                     return;
                 }
-                MessageConverser.convert(event.getMessage(), event);
+
                 resp.put("message", event.getMessage());
                 utils.pushAnyMessageEvent(bot, resp, event.getArrayMsg());
                 injection.invokePrivateMessage(bot, event);
@@ -98,7 +98,7 @@ public class MessageEvent {
                 if (utils.setInterceptor(bot, event)) {
                     return;
                 }
-                MessageConverser.convert(event.getMessage(), event);
+
                 resp.put("message", event.getMessage());
                 utils.pushAnyMessageEvent(bot, resp, event.getArrayMsg());
                 injection.invokeGroupMessage(bot, event);
@@ -111,7 +111,7 @@ public class MessageEvent {
                 if (utils.setInterceptor(bot, event)) {
                     return;
                 }
-                MessageConverser.convert(event.getMessage(), event);
+
                 injection.invokeGuildMessage(bot, event);
                 bot.getPluginList().stream().anyMatch(o -> utils.getPlugin(o).onGuildMessage(bot, event) == BotPlugin.MESSAGE_BLOCK);
                 utils.getInterceptor(bot.getBotMessageEventInterceptor()).afterCompletion(bot, event);

--- a/src/main/java/com/mikuac/shiro/model/ArrayMsg.java
+++ b/src/main/java/com/mikuac/shiro/model/ArrayMsg.java
@@ -62,20 +62,30 @@ public class ArrayMsg {
         return this;
     }
 
-    public ArrayMsg setData(Map<String, String> map) {
+    @JsonIgnore
+    public <T> ArrayMsg setData(Map<String, T> map) {
         if (data == null) {
             data = JsonUtils.getObjectMapper().createObjectNode();
         }
         map.forEach((key, value) -> {
             JsonNode valueNode;
             try {
-                valueNode = JsonUtils.getObjectMapper().readTree(value);
+                if (value instanceof String s) {
+                    valueNode = JsonUtils.getObjectMapper().readTree(s);
+                } else {
+                    valueNode = JsonUtils.getObjectMapper().valueToTree(value);
+                }
             } catch (Exception e) {
-                valueNode = JsonUtils.getObjectMapper().getNodeFactory().textNode(value);
+                valueNode = JsonUtils.getObjectMapper().getNodeFactory().textNode(value.toString());
             }
             ((ObjectNode) data).set(key, valueNode);
         });
         return this;
+    }
+
+    @JsonSetter("data")
+    private void setData(JsonNode node) {
+        data = node;
     }
 
     public String toCQCode() {

--- a/src/main/java/com/mikuac/shiro/model/ArrayMsg.java
+++ b/src/main/java/com/mikuac/shiro/model/ArrayMsg.java
@@ -1,5 +1,13 @@
 package com.mikuac.shiro.model;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.mikuac.shiro.common.utils.JsonUtils;
+import com.mikuac.shiro.common.utils.ShiroUtils;
 import com.mikuac.shiro.enums.MsgTypeEnum;
 import lombok.Data;
 import lombok.experimental.Accessors;
@@ -14,14 +22,18 @@ import java.util.Map;
 @Accessors(chain = true)
 public class ArrayMsg {
 
+    @JsonIgnore
     private String type;
 
-    private Map<String, String> data;
+    @JsonProperty("data")
+    private JsonNode data;
 
+    @JsonIgnore
     public MsgTypeEnum getType() {
         return MsgTypeEnum.typeOf(type);
     }
 
+    @JsonIgnore
     public ArrayMsg setType(MsgTypeEnum typeEnum) {
         if (typeEnum == null || !MsgTypeEnum.isValidMsgType(typeEnum)) {
             type = MsgTypeEnum.unknown.name();
@@ -29,6 +41,16 @@ public class ArrayMsg {
             type = typeEnum.name();
         }
         return this;
+    }
+
+    @JsonGetter("type")
+    private String getTypeString() {
+        return type;
+    }
+
+    @JsonSetter
+    public void setTypeString(String type) {
+        this.type = type;
     }
 
     public String getRawType() {
@@ -40,20 +62,52 @@ public class ArrayMsg {
         return this;
     }
 
+    public ArrayMsg setData(Map<String, String> map) {
+        if (data == null) {
+            data = JsonUtils.getObjectMapper().createObjectNode();
+        }
+        map.forEach((key, value) -> {
+            JsonNode valueNode;
+            try {
+                valueNode = JsonUtils.getObjectMapper().readTree(value);
+            } catch (Exception e) {
+                valueNode = JsonUtils.getObjectMapper().getNodeFactory().textNode(value);
+            }
+            ((ObjectNode) data).set(key, valueNode);
+        });
+        return this;
+    }
+
     public String toCQCode() {
         if ("text".equalsIgnoreCase(type)) {
-            return data.getOrDefault("text", "");
+            return getStringData("text");
         }
         StringBuilder stringBuilder = new StringBuilder("[CQ:");
         stringBuilder.append(getRawType());
-        data.forEach((key, val) -> {
+        data.properties().forEach((e) -> {
+
             stringBuilder.append(',');
-            stringBuilder.append(key);
+            stringBuilder.append(e.getKey());
             stringBuilder.append('=');
-            stringBuilder.append(val);
+            stringBuilder.append(ShiroUtils.escape(JsonUtils.nodeToString(e.getValue())));
         });
         stringBuilder.append(']');
         return stringBuilder.toString();
     }
 
+    public long getLongData(String key) {
+        var value = data.get(key);
+        if (value == null || !value.isLong()) {
+            return 0;
+        }
+        return value.asLong();
+    }
+
+    public String getStringData(String key) {
+        var value = data.get(key);
+        if (value == null) {
+            return "";
+        }
+        return JsonUtils.nodeToString(value);
+    }
 }


### PR DESCRIPTION
jackson 在序列化上更加严格, 无法将 object 类型写入到 string 中, 需要借助 `JsonNode` 中转一下

另外感觉对于 `ArrayMsg` 有很多多余的处理, 应该可以简化(比如`MessageConverser.convert()`先将obj转为string, 再转为obj 后再次转为string, 似乎是多余的)

## Sourcery 总结

通过在 ArrayMsg 和 MessageEvent 中切换到基于 JsonNode 的存储，并相应更新相关工具，以使消息序列化和反序列化适应更严格的 Jackson 规则。

Bug 修复:
- 通过 JsonNode 中介处理对象到字符串的转换，解决 Jackson 序列化错误

增强:
- 在 ArrayMsg 中用 JsonNode 替换 Map<String,String>，并引入 getLongData/getStringData 辅助方法
- 在 JsonUtils 中添加基于 JsonNode 的解析和 nodeToString 方法，以改进 JSON 转换
- 简化 MessageConverser，将 CQ 代码生成委托给 ArrayMsg.toCQCode，并简化转换逻辑
- 在 ArrayMsg 和 MessageEvent 中引入 Jackson @JsonGetter/@JsonSetter 注解，以支持混合 JSON 格式
- 更新 CommonUtils、ShiroUtils 和 ActionHandler，使用基于 JsonNode 的数据访问而不是手动解析
- 从属性文件配置 WebSocketServerHandler 中的文本和二进制消息大小限制

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adapt message serialization and deserialization to stricter Jackson rules by switching to JsonNode-backed storage in ArrayMsg and MessageEvent and updating related utilities accordingly

Bug Fixes:
- Resolve Jackson serialization errors by handling object-to-string conversion via JsonNode intermediary

Enhancements:
- Replace Map<String,String> with JsonNode in ArrayMsg and introduce getLongData/getStringData helpers
- Add JsonNode-based parsing and nodeToString methods in JsonUtils for improved JSON conversions
- Simplify MessageConverser to delegate CQ code generation to ArrayMsg.toCQCode and streamline convert logic
- Introduce Jackson @JsonGetter/@JsonSetter annotations in ArrayMsg and MessageEvent to support mixed JSON formats
- Update CommonUtils, ShiroUtils, and ActionHandler to use JsonNode-based data access instead of manual parsing
- Configure text and binary message size limits in WebSocketServerHandler from properties

</details>