### PR TITLE
替换 fastjson2 为 jackson

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,6 @@ version = "2.4.5"
 
 val mavenArtifactResolver = "1.9.24"
 val mavenResolverProvider = "3.9.11"
-val fastjson = "2.0.57"
 val junit = "5.13.3"
 
 plugins {
@@ -59,11 +58,9 @@ repositories {
 }
 
 dependencies {
-    api("com.alibaba.fastjson2:fastjson2:$fastjson")
     api("org.springframework.boot:spring-boot-starter-websocket")
 
     api("org.apache.maven:maven-resolver-provider:$mavenResolverProvider")
-
     api("org.apache.maven.resolver:maven-resolver-connector-basic:$mavenArtifactResolver")
     api("org.apache.maven.resolver:maven-resolver-transport-file:$mavenArtifactResolver")
     api("org.apache.maven.resolver:maven-resolver-transport-http:$mavenArtifactResolver")
@@ -73,6 +70,7 @@ dependencies {
     api("org.apache.maven.resolver:maven-resolver-spi:$mavenArtifactResolver")
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.junit.jupiter:junit-jupiter:$junit")
 }

--- a/src/main/java/com/mikuac/shiro/action/OneBot.java
+++ b/src/main/java/com/mikuac/shiro/action/OneBot.java
@@ -292,7 +292,7 @@ public interface OneBot {
      *
      * @return result {@link GetStatusResp}
      */
-    GetStatusResp getStatus();
+    ActionData<GetStatusResp> getStatus();
 
     /**
      * 群组匿名用户禁言

--- a/src/main/java/com/mikuac/shiro/adapter/WebSocketClientHandler.java
+++ b/src/main/java/com/mikuac/shiro/adapter/WebSocketClientHandler.java
@@ -1,9 +1,9 @@
 package com.mikuac.shiro.adapter;
 
-import com.alibaba.fastjson2.JSON;
-import com.alibaba.fastjson2.JSONObject;
 import com.mikuac.shiro.common.utils.CommonUtils;
 import com.mikuac.shiro.common.utils.ConnectionUtils;
+import com.mikuac.shiro.common.utils.JsonObjectWrapper;
+import com.mikuac.shiro.common.utils.JsonUtils;
 import com.mikuac.shiro.constant.Connection;
 import com.mikuac.shiro.core.Bot;
 import com.mikuac.shiro.core.BotContainer;
@@ -98,9 +98,9 @@ public class WebSocketClientHandler extends TextWebSocketHandler {
     protected void handleTextMessage(@NonNull WebSocketSession session, @NonNull TextMessage message) {
         long xSelfId = ConnectionUtils.parseSelfId(session);
         if (xSelfId == 0L) {
-            boolean valid = JSON.isValid(message.getPayload());
+            boolean valid = JsonUtils.isValid(message.getPayload());
             if (valid) {
-                String selfId = JSONObject.parseObject(message.getPayload()).getOrDefault(Connection.SELF_ID, "").toString();
+                String selfId = JsonObjectWrapper.parseObject(message.getPayload()).getOrDefault(Connection.SELF_ID, "").toString();
                 session.getAttributes().put(Connection.X_SELF_ID, selfId);
                 xSelfId = ConnectionUtils.parseSelfId(session);
             }
@@ -108,7 +108,7 @@ public class WebSocketClientHandler extends TextWebSocketHandler {
                 afterConnectionEstablished(session);
             }
         }
-        JSONObject result = JSON.parseObject(message.getPayload());
+        JsonObjectWrapper result = JsonObjectWrapper.parseObject(message.getPayload());
         log.debug("[Event] {}", CommonUtils.debugMsgDeleteBase64Content(result.toJSONString()));
         // if resp contains echo field, this resp is action resp, else event resp.
         if (result.containsKey(Connection.API_RESULT_KEY)) {

--- a/src/main/java/com/mikuac/shiro/adapter/WebSocketServerHandler.java
+++ b/src/main/java/com/mikuac/shiro/adapter/WebSocketServerHandler.java
@@ -1,9 +1,8 @@
 package com.mikuac.shiro.adapter;
 
-import com.alibaba.fastjson2.JSON;
-import com.alibaba.fastjson2.JSONObject;
 import com.mikuac.shiro.common.utils.CommonUtils;
 import com.mikuac.shiro.common.utils.ConnectionUtils;
+import com.mikuac.shiro.common.utils.JsonObjectWrapper;
 import com.mikuac.shiro.constant.Connection;
 import com.mikuac.shiro.core.Bot;
 import com.mikuac.shiro.core.BotContainer;
@@ -104,6 +103,7 @@ public class WebSocketServerHandler extends TextWebSocketHandler {
                 }
                 return;
             }
+            // noinspection resource
             botContainer.robots.compute(xSelfId, (id, bot) -> {
                 if (Objects.isNull(bot)) {
                     bot = ConnectionUtils.handleFirstConnect(xSelfId, session, botFactory, coreEvent, shiroTaskExecutor);
@@ -127,6 +127,7 @@ public class WebSocketServerHandler extends TextWebSocketHandler {
 
         if (shiroProps.getWaitBotConnect() <= 0) {
             sessionContext.clear();
+            // noinspection resource
             botContainer.robots.remove(xSelfId);
             log.warn("Account {} disconnected", xSelfId);
             CompletableFuture.runAsync(() -> coreEvent.offline(xSelfId), shiroTaskExecutor);
@@ -136,6 +137,7 @@ public class WebSocketServerHandler extends TextWebSocketHandler {
         // if not reconnected within a certain timeframe, execute the deletion scheduled task
         ScheduledFuture<?> removeSelfFuture = scheduledTask.executor().schedule(() -> {
             if (botContainer.robots.containsKey(xSelfId)) {
+                // noinspection resource
                 botContainer.robots.remove(xSelfId);
                 log.warn("Account {} disconnected", xSelfId);
                 CompletableFuture.runAsync(() -> coreEvent.offline(xSelfId), shiroTaskExecutor);
@@ -149,7 +151,7 @@ public class WebSocketServerHandler extends TextWebSocketHandler {
     @SuppressWarnings("Duplicates")
     protected void handleTextMessage(@NonNull WebSocketSession session, @NonNull TextMessage message) {
         long xSelfId = ConnectionUtils.parseSelfId(session);
-        JSONObject result = JSON.parseObject(message.getPayload());
+        JsonObjectWrapper result = JsonObjectWrapper.parseObject(message.getPayload());
         log.debug("[Event] {}", CommonUtils.debugMsgDeleteBase64Content(result.toJSONString()));
         // if resp contains echo field, this resp is action resp, else event resp.
         if (result.containsKey(Connection.API_RESULT_KEY)) {

--- a/src/main/java/com/mikuac/shiro/adapter/WebSocketServerHandler.java
+++ b/src/main/java/com/mikuac/shiro/adapter/WebSocketServerHandler.java
@@ -73,6 +73,8 @@ public class WebSocketServerHandler extends TextWebSocketHandler {
     @Override
     public void afterConnectionEstablished(@NonNull WebSocketSession session) {
         try {
+            session.setTextMessageSizeLimit(wsProp.getMaxTextMessageBufferSize());
+            session.setBinaryMessageSizeLimit(wsProp.getMaxBinaryMessageBufferSize());
             session.getAttributes().put(Connection.ADAPTER_KEY, AdapterEnum.SERVER);
             long xSelfId = ConnectionUtils.parseSelfId(session);
             if (xSelfId == 0L) {
@@ -91,7 +93,6 @@ public class WebSocketServerHandler extends TextWebSocketHandler {
             }
             var sessionContext = session.getAttributes();
             sessionContext.put(Connection.SESSION_STATUS_KEY, SessionStatusEnum.ONLINE);
-
             if (shiroProps.getWaitBotConnect() <= 0) {
                 if (botContainer.robots.containsKey(xSelfId)) {
                     log.info("Bot {} already connected with another instance", xSelfId);

--- a/src/main/java/com/mikuac/shiro/boot/Shiro.java
+++ b/src/main/java/com/mikuac/shiro/boot/Shiro.java
@@ -9,7 +9,6 @@ import com.mikuac.shiro.handler.ActionHandler;
 import com.mikuac.shiro.handler.EventHandler;
 import com.mikuac.shiro.properties.ShiroProperties;
 import com.mikuac.shiro.properties.WebSocketProperties;
-import com.mikuac.shiro.properties.WebSocketServerProperties;
 import com.mikuac.shiro.task.ScheduledTask;
 import com.mikuac.shiro.task.ShiroAsyncTask;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +18,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
-import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean;
 
 /**
  * Created on 2021/7/16.
@@ -30,7 +28,6 @@ import org.springframework.web.socket.server.standard.ServletServerContainerFact
 @Configuration
 public class Shiro {
 
-    private final WebSocketServerProperties wsServerProp;
     private final WebSocketProperties wsProp;
     private final BotFactory botFactory;
     private final EventHandler eventHandler;
@@ -44,12 +41,11 @@ public class Shiro {
 
     @Autowired
     public Shiro(
-            WebSocketServerProperties wsServerProp, WebSocketProperties wsProp, BotFactory botFactory,
+            WebSocketProperties wsProp, BotFactory botFactory,
             EventHandler eventHandler, ActionHandler actionHandler, ShiroAsyncTask shiroAsyncTask,
             BotContainer botContainer, CoreEvent coreEvent, ScheduledTask scheduledTask, ShiroProperties shiroProps,
             @Qualifier("shiroTaskExecutor") ThreadPoolTaskExecutor shiroTaskExecutor
     ) {
-        this.wsServerProp = wsServerProp;
         this.wsProp = wsProp;
         this.botFactory = botFactory;
         this.eventHandler = eventHandler;
@@ -81,16 +77,6 @@ public class Shiro {
                 eventHandler, botFactory, actionHandler, shiroAsyncTask,
                 botContainer, coreEvent, wsProp, shiroTaskExecutor
         );
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public ServletServerContainerFactoryBean createWebSocketServerContainer() {
-        ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();
-        container.setMaxTextMessageBufferSize(wsProp.getMaxTextMessageBufferSize());
-        container.setMaxBinaryMessageBufferSize(wsProp.getMaxBinaryMessageBufferSize());
-        container.setMaxSessionIdleTimeout(wsServerProp.getMaxSessionIdleTimeout());
-        return container;
     }
 
 }

--- a/src/main/java/com/mikuac/shiro/common/utils/ArrayMsgUtils.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/ArrayMsgUtils.java
@@ -1,6 +1,5 @@
 package com.mikuac.shiro.common.utils;
 
-import com.alibaba.fastjson2.JSON;
 import com.mikuac.shiro.model.ArrayMsg;
 
 import java.util.*;
@@ -187,7 +186,7 @@ public class ArrayMsgUtils {
         builder.add(getJsonData("markdown", m -> {
             HashMap<String, String> map = new HashMap<>();
             map.put("content", content);
-            m.put("content", JSON.toJSONString(map));
+            m.put("content", JsonUtils.toJSONString(map));
         }));
         return this;
     }
@@ -205,7 +204,7 @@ public class ArrayMsgUtils {
      * }</pre>
      */
     public ArrayMsgUtils keyboard(Keyboard keyboard) {
-        builder.add(getJsonData("keyboard", m -> m.put("keyboard", JSON.toJSONString(keyboard))));
+        builder.add(getJsonData("keyboard", m -> m.put("keyboard", JsonUtils.toJSONString(keyboard))));
         return this;
     }
 

--- a/src/main/java/com/mikuac/shiro/common/utils/CommonUtils.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/CommonUtils.java
@@ -169,7 +169,7 @@ public class CommonUtils {
         }
         ArrayMsg item = atParse(arrayMsg, selfId);
         if (item != null) {
-            String code = MessageConverser.arrayToString(arrayMsg.get(arrayMsg.indexOf(item)));
+            String code = arrayMsg.get(arrayMsg.indexOf(item)).toCQCode();
             return msg.replace(code, "").trim();
         }
         return msg;

--- a/src/main/java/com/mikuac/shiro/common/utils/CommonUtils.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/CommonUtils.java
@@ -37,11 +37,11 @@ public class CommonUtils {
         Optional<ArrayMsg> opt = Optional.ofNullable(atParse(arrayMsg, selfId));
         return switch (at) {
             case NEED -> opt.map(item -> {
-                long target = Long.parseLong(item.getData().get("qq"));
+                long target = item.getLongData("qq");
                 return target == 0L || target != selfId;
             }).orElse(true);
             case NOT_NEED -> opt.map(item -> {
-                long target = Long.parseLong(item.getData().get("qq"));
+                long target = item.getLongData("qq");
                 return target == selfId;
             }).orElse(false);
             default -> false;
@@ -88,8 +88,8 @@ public class CommonUtils {
                 case OFF -> throw new ShiroException("exception that cannot be thrown");
                 case NONE -> reply.isEmpty();
                 case REPLY_ALL -> reply.isPresent();
-                case REPLY_ME -> reply.map(e -> e.getData().get("qq").equals(String.valueOf(selfId))).orElse(false);
-                case REPLY_OTHER -> reply.map(e -> !e.getData().get("qq").equals(String.valueOf(selfId))).orElse(false);
+                case REPLY_ME -> reply.map(e -> e.getLongData("qq") == selfId).orElse(false);
+                case REPLY_OTHER -> reply.map(e -> e.getLongData("qq") != selfId).orElse(false);
             };
             if (!flag) return new CheckResult();
         }
@@ -186,8 +186,7 @@ public class CommonUtils {
         }
         int index = 0;
         ArrayMsg item = arrayMsg.get(index);
-        String rawTarget = item.getData().getOrDefault("qq", "0");
-        long target = Long.parseLong(CommonEnum.AT_ALL.value().equals(rawTarget) ? "0" : rawTarget);
+        long target = item.getLongData("qq");
         index = arrayMsg.size() - 1;
         if ((target == 0L || target != selfId) && index >= 0) {
             item = arrayMsg.get(index);
@@ -196,8 +195,7 @@ public class CommonUtils {
             if (MsgTypeEnum.text == item.getType() && index >= 0) {
                 item = arrayMsg.get(index);
             }
-            rawTarget = item.getData().getOrDefault("qq", "0");
-            target = Long.parseLong(CommonEnum.AT_ALL.value().equals(rawTarget) ? "0" : rawTarget);
+            target = item.getLongData("qq");
             if (target == 0L || target != selfId) {
                 return null;
             }

--- a/src/main/java/com/mikuac/shiro/common/utils/EventUtils.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/EventUtils.java
@@ -1,6 +1,5 @@
 package com.mikuac.shiro.common.utils;
 
-import com.alibaba.fastjson2.JSONObject;
 import com.mikuac.shiro.core.Bot;
 import com.mikuac.shiro.core.BotMessageEventInterceptor;
 import com.mikuac.shiro.core.BotPlugin;
@@ -86,10 +85,10 @@ public class EventUtils {
      * 推送消息
      *
      * @param bot      {@link Bot}
-     * @param resp     {@link JSONObject}
+     * @param resp     {@link JsonObjectWrapper}
      * @param arrayMsg {@link ArrayMsg}
      */
-    public void pushAnyMessageEvent(Bot bot, JSONObject resp, List<ArrayMsg> arrayMsg) {
+    public void pushAnyMessageEvent(Bot bot, JsonObjectWrapper resp, List<ArrayMsg> arrayMsg) {
         try {
             AnyMessageEvent event = resp.to(AnyMessageEvent.class);
             event.setArrayMsg(arrayMsg);

--- a/src/main/java/com/mikuac/shiro/common/utils/JsonObjectWrapper.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/JsonObjectWrapper.java
@@ -1,0 +1,120 @@
+package com.mikuac.shiro.common.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public class JsonObjectWrapper {
+
+    private final ObjectNode objectNode;
+    private final ObjectMapper objectMapper;
+
+    public JsonObjectWrapper() {
+        this.objectMapper = JsonUtils.getObjectMapper();
+        this.objectNode = objectMapper.createObjectNode();
+    }
+
+    public JsonObjectWrapper(ObjectNode objectNode) {
+        this.objectMapper = JsonUtils.getObjectMapper();
+        this.objectNode = objectNode;
+    }
+
+    public JsonObjectWrapper(String jsonString) {
+        this.objectMapper = JsonUtils.getObjectMapper();
+        JsonNode node = JsonUtils.parseObject(jsonString);
+        if (node instanceof ObjectNode v) {
+            this.objectNode = v;
+        } else {
+            this.objectNode = objectMapper.createObjectNode();
+        }
+    }
+
+    public JsonObjectWrapper put(String key, Object obj) {
+        if (obj == null) {
+            objectNode.putNull(key);
+        } else if (obj instanceof String value) {
+            objectNode.put(key, value);
+        } else if (obj instanceof Integer value) {
+            objectNode.put(key, value);
+        } else if (obj instanceof Long value) {
+            objectNode.put(key, value);
+        } else if (obj instanceof Boolean value) {
+            objectNode.put(key, value);
+        } else if (obj instanceof Double value) {
+            objectNode.put(key, value);
+        } else if (obj instanceof Float value) {
+            objectNode.put(key, value);
+        } else {
+            // valueToTree 性能开销会更大一些，所以尽量先判断类型
+            objectNode.set(key, objectMapper.valueToTree(obj));
+        }
+        return this;
+    }
+
+    public Object get(String key) {
+        JsonNode node = objectNode.get(key);
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (node.isTextual()) {
+            return node.asText();
+        }
+        if (node.isInt()) {
+            return node.asInt();
+        }
+        if (node.isLong()) {
+            return node.asLong();
+        }
+        if (node.isBoolean()) {
+            return node.asBoolean();
+        }
+        if (node.isDouble()) {
+            return node.asDouble();
+        }
+        return node;
+    }
+
+    public String getString(String key) {
+        JsonNode node = objectNode.get(key);
+        return node != null ? node.asText() : null;
+    }
+
+    public boolean containsKey(String key) {
+        return objectNode.has(key);
+    }
+
+    public Object getOrDefault(String key, Object defaultValue) {
+        Object value = get(key);
+        return value != null ? value : defaultValue;
+    }
+
+    public void clear() {
+        objectNode.removeAll();
+    }
+
+    public <T> T to(Class<T> clazz) {
+        try {
+            return objectMapper.treeToValue(objectNode, clazz);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public String toJSONString() {
+        try {
+            return objectMapper.writeValueAsString(objectNode);
+        } catch (Exception e) {
+            return JsonUtils.toJSONString(objectNode);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return toJSONString();
+    }
+
+    public static JsonObjectWrapper parseObject(String jsonString) {
+        return new JsonObjectWrapper(jsonString);
+    }
+
+}

--- a/src/main/java/com/mikuac/shiro/common/utils/JsonUtils.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/JsonUtils.java
@@ -1,0 +1,104 @@
+package com.mikuac.shiro.common.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+@Slf4j
+@SuppressWarnings("unused")
+public class JsonUtils {
+
+    private JsonUtils() {
+    }
+
+    private static final ObjectMapper DEFAULT_OBJECT_MAPPER = createConfiguredObjectMapper();
+
+    private static final AtomicReference<ObjectMapper> customObjectMapper = new AtomicReference<>();
+
+    private static ObjectMapper createConfiguredObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        // 忽略 JSON 中存在但 Java 对象不存在的字段，避免因字段变动导致反序列化失败
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        // 序列化时不因空 Bean 报错
+        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        return mapper;
+    }
+
+    public static void setCustomObjectMapper(@Nullable ObjectMapper mapper) {
+        customObjectMapper.set(mapper);
+    }
+
+    public static ObjectMapper getObjectMapper() {
+        ObjectMapper mapper = customObjectMapper.get();
+        return mapper != null ? mapper : DEFAULT_OBJECT_MAPPER;
+    }
+
+    @Nullable
+    public static JsonNode parseObject(String jsonString) {
+        try {
+            return getObjectMapper().readTree(jsonString);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to parse JSON string: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    public static <T> List<T> parseArray(String jsonString, Class<T> clazz) {
+        try {
+            ObjectMapper mapper = getObjectMapper();
+            return mapper.readValue(jsonString,
+                    mapper.getTypeFactory().constructCollectionType(List.class, clazz));
+        } catch (JsonProcessingException e) {
+            log.error("Failed to parse JSON array: {}", e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+
+    @Nullable
+    public static String toJSONString(Object object) {
+        try {
+            return getObjectMapper().writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to convert object to JSON string: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    public static boolean isValid(String jsonString) {
+        try {
+            getObjectMapper().readTree(jsonString);
+            return true;
+        } catch (JsonProcessingException e) {
+            return false;
+        }
+    }
+
+    public static boolean isValidArray(String jsonString) {
+        try {
+            JsonNode node = getObjectMapper().readTree(jsonString);
+            return node != null && node.isArray();
+        } catch (JsonProcessingException e) {
+            return false;
+        }
+    }
+
+    @Nullable
+    public static <T> T readValue(String jsonString, TypeReference<T> typeReference) {
+        try {
+            return getObjectMapper().readValue(jsonString, typeReference);
+        } catch (Exception e) {
+            log.error("Failed to read value with TypeReference: {}", e.getMessage());
+            return null;
+        }
+    }
+
+} 

--- a/src/main/java/com/mikuac/shiro/common/utils/JsonUtils.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/JsonUtils.java
@@ -52,17 +52,6 @@ public class JsonUtils {
         }
     }
 
-    public static <T> List<T> parseArray(String jsonString, Class<T> clazz) {
-        try {
-            ObjectMapper mapper = getObjectMapper();
-            return mapper.readValue(jsonString,
-                    mapper.getTypeFactory().constructCollectionType(List.class, clazz));
-        } catch (JsonProcessingException e) {
-            log.error("Failed to parse JSON array: {}", e.getMessage());
-            return Collections.emptyList();
-        }
-    }
-
     public static <T> List<T> parseArray(JsonNode json, Class<T> clazz) {
         try {
             ObjectMapper mapper = getObjectMapper();
@@ -93,15 +82,6 @@ public class JsonUtils {
         }
     }
 
-    public static boolean isValidArray(String jsonString) {
-        try {
-            JsonNode node = getObjectMapper().readTree(jsonString);
-            return node != null && node.isArray();
-        } catch (JsonProcessingException e) {
-            return false;
-        }
-    }
-
     @Nullable
     public static <T> T readValue(String jsonString, TypeReference<T> typeReference) {
         try {
@@ -125,4 +105,5 @@ public class JsonUtils {
             return node.toString();
         }
     }
+
 } 

--- a/src/main/java/com/mikuac/shiro/common/utils/JsonUtils.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/JsonUtils.java
@@ -63,6 +63,17 @@ public class JsonUtils {
         }
     }
 
+    public static <T> List<T> parseArray(JsonNode json, Class<T> clazz) {
+        try {
+            ObjectMapper mapper = getObjectMapper();
+            return mapper.convertValue(json,
+                    mapper.getTypeFactory().constructCollectionType(List.class, clazz));
+        } catch (IllegalArgumentException e) {
+            log.error("Failed to parse JSON array: {}", e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+
     @Nullable
     public static String toJSONString(Object object) {
         try {
@@ -101,4 +112,17 @@ public class JsonUtils {
         }
     }
 
+    public static String nodeToString(JsonNode node) {
+        if (node == null) {
+            return "";
+        }
+        if (node.isTextual()) {
+            return node.textValue();
+        }
+        try {
+            return getObjectMapper().writeValueAsString(node);
+        } catch (JsonProcessingException e) {
+            return node.toString();
+        }
+    }
 } 

--- a/src/main/java/com/mikuac/shiro/common/utils/JsonUtils.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/JsonUtils.java
@@ -1,6 +1,8 @@
 package com.mikuac.shiro.common.utils;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -9,6 +11,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.lang.Nullable;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -106,4 +109,25 @@ public class JsonUtils {
         }
     }
 
-} 
+    public static JsonNode parseToJsonNode(Object value) {
+        ObjectMapper mapper = getObjectMapper();
+        if (value instanceof String s) {
+            try (JsonParser parser = mapper.createParser(s)) {
+                JsonToken first = parser.nextToken();
+                if (first == null) {
+                    return mapper.getNodeFactory().textNode(s);
+                }
+                JsonNode node = mapper.readTree(parser);
+                if (parser.nextToken() == null) {
+                    return node;
+                }
+            } catch (IOException ignored) {
+                // ignored
+            }
+            return mapper.getNodeFactory().textNode(s);
+        } else {
+            return mapper.valueToTree(value);
+        }
+    }
+
+}

--- a/src/main/java/com/mikuac/shiro/common/utils/Keyboard.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/Keyboard.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.common.utils;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -104,13 +104,13 @@ public class Keyboard {
         /**
          * 按钮ID：在一个keyboard消息内设置唯一
          */
-        @JSONField(name = "id")
+        @JsonProperty("id")
         private String id;
 
-        @JSONField(name = "render_data")
+        @JsonProperty("render_data")
         private RenderData renderData = new RenderData();
 
-        @JSONField(name = "action")
+        @JsonProperty("action")
         private Action action = new Action();
     }
 
@@ -121,19 +121,19 @@ public class Keyboard {
         /**
          * 按钮上的文字
          */
-        @JSONField(name = "label")
+        @JsonProperty("label")
         private String label;
 
         /**
          * 点击后按钮的上文字
          */
-        @JSONField(name = "visited_label")
+        @JsonProperty("visited_label")
         private String visitedLabel;
 
         /**
          * 按钮样式：0 灰色线框，1 蓝色线框
          */
-        @JSONField(name = "style")
+        @JsonProperty("style")
         private Integer style;
     }
 
@@ -146,31 +146,31 @@ public class Keyboard {
          * 设置 1 回调按钮：回调后台接口, data 传给后台，<br/>
          * 设置 2 指令按钮：自动在输入框插入 @bot data <br/>
          */
-        @JSONField(name = "type")
+        @JsonProperty("type")
         private int type;
 
         /**
          * 权限设置
          */
-        @JSONField(name = "permission")
+        @JsonProperty("permission")
         private Permission permission = new Permission();
 
         /**
          * 操作相关的数据
          */
-        @JSONField(name = "data")
+        @JsonProperty("data")
         private String data = "";
 
         /**
          * 指令按钮可用，指令是否带引用回复本消息，默认 false。支持版本 8983
          */
-        @JSONField(name = "reply")
+        @JsonProperty("reply")
         private Boolean reply;
 
         /**
          * 指令按钮可用，点击按钮后直接自动发送 data，默认 false。支持版本 8983
          */
-        @JSONField(name = "enter")
+        @JsonProperty("enter")
         private Boolean enter;
 
         /**
@@ -178,13 +178,13 @@ public class Keyboard {
          * 设置为 1 时 ，点击按钮自动唤起启手Q选图器，其他值暂无效果。
          * 仅支持手机端版本 8983+ 的单聊场景，桌面端不支持）
          */
-        @JSONField(name = "anchor")
+        @JsonProperty("anchor")
         private Integer anchor;
 
         /**
          * 客户端不支持本action的时候，弹出的toast文案
          */
-        @JSONField(name = "unsupport_tips")
+        @JsonProperty("unsupport_tips")
         private String unSupportTips;
     }
 
@@ -198,19 +198,19 @@ public class Keyboard {
          * 2 所有人可操作，<br/>
          * 3 指定身份组可操作（仅频道可用）<br/>
          */
-        @JSONField(name = "type")
+        @JsonProperty("type")
         private Integer type;
 
         /**
          * 有权限的用户 id 的列表
          */
-        @JSONField(name = "specify_user_ids")
+        @JsonProperty("specify_user_ids")
         private List<String> specifyUserIds;
 
         /**
          * 有权限的身份组 id 的列表（仅频道可用）
          */
-        @JSONField(name = "specify_role_ids")
+        @JsonProperty("specify_role_ids")
         private List<String> specifyRoleIds;
     }
 

--- a/src/main/java/com/mikuac/shiro/common/utils/MessageConverser.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/MessageConverser.java
@@ -1,21 +1,18 @@
 package com.mikuac.shiro.common.utils;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.mikuac.shiro.dto.event.message.MessageEvent;
 import com.mikuac.shiro.enums.MsgTypeEnum;
 import com.mikuac.shiro.model.ArrayMsg;
 import lombok.NonNull;
-import org.springframework.util.CollectionUtils;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class MessageConverser {
 
     private MessageConverser() {
-    }
-
-    public static String arrayToString(ArrayMsg arrayMsg) {
-        return arrayMsg.toCQCode();
     }
 
     public static String arraysToString(List<ArrayMsg> array) {
@@ -149,4 +146,5 @@ public class MessageConverser {
         item.setData(data);
         chain.add(item);
     }
+
 }

--- a/src/main/java/com/mikuac/shiro/common/utils/MessageConverser.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/MessageConverser.java
@@ -1,6 +1,5 @@
 package com.mikuac.shiro.common.utils;
 
-import com.alibaba.fastjson2.JSON;
 import com.mikuac.shiro.dto.event.message.MessageEvent;
 import com.mikuac.shiro.enums.MsgTypeEnum;
 import com.mikuac.shiro.model.ArrayMsg;
@@ -161,8 +160,8 @@ public class MessageConverser {
 
     public static void convert(@NonNull String msg, MessageEvent event) {
         // 如果 msg 是一个有效的 json 数组则作为 array 上报
-        if (JSON.isValidArray(msg)) {
-            List<ArrayMsg> arrayMsg = JSON.parseArray(msg, ArrayMsg.class);
+        if (JsonUtils.isValidArray(msg)) {
+            List<ArrayMsg> arrayMsg = JsonUtils.parseArray(msg, ArrayMsg.class);
             // 将 array 转换回 string
             event.setArrayMsg(arrayMsg);
             event.setMessage(arraysToString(arrayMsg));

--- a/src/main/java/com/mikuac/shiro/common/utils/MessageConverser.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/MessageConverser.java
@@ -1,9 +1,11 @@
 package com.mikuac.shiro.common.utils;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.mikuac.shiro.dto.event.message.MessageEvent;
 import com.mikuac.shiro.enums.MsgTypeEnum;
 import com.mikuac.shiro.model.ArrayMsg;
 import lombok.NonNull;
+import org.springframework.util.CollectionUtils;
 
 import java.util.*;
 
@@ -13,27 +15,16 @@ public class MessageConverser {
     }
 
     public static String arrayToString(ArrayMsg arrayMsg) {
-        StringBuilder builder = new StringBuilder();
-        if (Objects.isNull(arrayMsg.getType()) || MsgTypeEnum.unknown.equals(arrayMsg.getType())) {
-            builder.append("[CQ:").append(MsgTypeEnum.unknown);
-        } else {
-            builder.append("[CQ:").append(arrayMsg.getType());
-        }
-        arrayMsg.getData().forEach((k, v) -> builder.append(",").append(k).append("=").append(ShiroUtils.escape(v)));
-        builder.append("]");
-        return builder.toString();
+        return arrayMsg.toCQCode();
     }
 
     public static String arraysToString(List<ArrayMsg> array) {
         StringBuilder builder = new StringBuilder();
         for (ArrayMsg item : array) {
             if (!MsgTypeEnum.text.equals(item.getType())) {
-                builder.append("[CQ:").append(item.getType());
-                // message 字段转回 CQ 码的时候不要转义，raw_message 会保留原始内容。
-                item.getData().forEach((k, v) -> builder.append(",").append(k).append("=").append(v));
-                builder.append("]");
+                builder.append(item.toCQCode());
             } else {
-                builder.append(ShiroUtils.escape(item.getData().get(MsgTypeEnum.text.toString())));
+                builder.append(item.getStringData(MsgTypeEnum.text.toString()));
             }
         }
         return builder.toString();
@@ -144,8 +135,9 @@ public class MessageConverser {
         // 检查最后一个消息是否为文本类型，如果是则合并
         if (!chain.isEmpty()) {
             ArrayMsg lastMsg = chain.get(chain.size() - 1);
-            if (lastMsg.getType() == MsgTypeEnum.text) {
-                lastMsg.getData().compute("text", (k, existingText) -> existingText + ShiroUtils.unescape(text));
+            if (lastMsg.getType() == MsgTypeEnum.text && lastMsg.getData().isObject()) {
+                ObjectNode obj = (ObjectNode) lastMsg.getData();
+                obj.put("text", obj.get("text").asText("") + ShiroUtils.unescape(text));
                 return;
             }
         }
@@ -157,18 +149,4 @@ public class MessageConverser {
         item.setData(data);
         chain.add(item);
     }
-
-    public static void convert(@NonNull String msg, MessageEvent event) {
-        // 如果 msg 是一个有效的 json 数组则作为 array 上报
-        if (JsonUtils.isValidArray(msg)) {
-            List<ArrayMsg> arrayMsg = JsonUtils.parseArray(msg, ArrayMsg.class);
-            // 将 array 转换回 string
-            event.setArrayMsg(arrayMsg);
-            event.setMessage(arraysToString(arrayMsg));
-            return;
-        }
-        // string 上报
-        event.setArrayMsg(stringToArray(msg));
-    }
-
 }

--- a/src/main/java/com/mikuac/shiro/common/utils/PayloadSender.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/PayloadSender.java
@@ -1,7 +1,5 @@
 package com.mikuac.shiro.common.utils;
 
-import com.alibaba.fastjson2.JSONObject;
-import com.alibaba.fastjson2.JSONWriter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.socket.TextMessage;
@@ -31,16 +29,16 @@ public class PayloadSender {
         this.timeout = timeout;
     }
 
-    private JSONObject resp;
+    private JsonObjectWrapper resp;
 
     private static final Lock lock = new ReentrantLock();
 
     private final Condition condition = lock.newCondition();
 
-    public JSONObject send(@NonNull JSONObject payload) {
+    public JsonObjectWrapper send(@NonNull JsonObjectWrapper payload) {
         lock.lock();
         try {
-            String json = payload.toJSONString(JSONWriter.Feature.LargeObject);
+            String json = payload.toJSONString();
             session.sendMessage(new TextMessage(json));
             log.debug("[Action] {}", CommonUtils.debugMsgDeleteBase64Content(json));
             long startTime = System.currentTimeMillis();
@@ -66,7 +64,7 @@ public class PayloadSender {
         return resp;
     }
 
-    public void onCallback(JSONObject resp) {
+    public void onCallback(JsonObjectWrapper resp) {
         lock.lock();
         try {
             this.resp = resp;

--- a/src/main/java/com/mikuac/shiro/common/utils/ShiroUtils.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/ShiroUtils.java
@@ -38,7 +38,7 @@ public class ShiroUtils {
      * @return 是否为全体at
      */
     public static boolean isAtAll(List<ArrayMsg> arrayMsg) {
-        return arrayMsg.stream().anyMatch(it -> "all".equals(it.getData().get("qq")));
+        return arrayMsg.stream().anyMatch(it -> it.getType().equals(MsgTypeEnum.at) && it.getLongData("qq") == 0L);
     }
 
     /**
@@ -50,8 +50,8 @@ public class ShiroUtils {
     public static List<Long> getAtList(List<ArrayMsg> arrayMsg) {
         return arrayMsg
                 .stream()
-                .filter(it -> MsgTypeEnum.at == it.getType() && !"all".equals(it.getData().get("qq")))
-                .map(it -> Long.parseLong(it.getData().get("qq")))
+                .filter(it -> MsgTypeEnum.at == it.getType() && it.getLongData("qq") != 0L)
+                .map(it -> it.getLongData("qq"))
                 .toList();
     }
 
@@ -64,7 +64,8 @@ public class ShiroUtils {
     public static List<String> getMsgImgUrlList(List<ArrayMsg> arrayMsg) {
         return arrayMsg
                 .stream()
-                .filter(it -> MsgTypeEnum.image == it.getType()).map(it -> it.getData().get("url"))
+                .filter(it -> MsgTypeEnum.image == it.getType())
+                .map(it -> it.getStringData("url"))
                 .toList();
     }
 
@@ -77,7 +78,8 @@ public class ShiroUtils {
     public static List<String> getMsgVideoUrlList(List<ArrayMsg> arrayMsg) {
         return arrayMsg
                 .stream()
-                .filter(it -> MsgTypeEnum.video == it.getType()).map(it -> it.getData().get("url"))
+                .filter(it -> MsgTypeEnum.video == it.getType())
+                .map(it -> it.getStringData("url"))
                 .toList();
     }
 

--- a/src/main/java/com/mikuac/shiro/core/Bot.java
+++ b/src/main/java/com/mikuac/shiro/core/Bot.java
@@ -1,9 +1,10 @@
 package com.mikuac.shiro.core;
 
-import com.alibaba.fastjson2.JSONObject;
-import com.alibaba.fastjson2.TypeReference;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.mikuac.shiro.action.*;
 import com.mikuac.shiro.common.utils.ConnectionUtils;
+import com.mikuac.shiro.common.utils.JsonObjectWrapper;
+import com.mikuac.shiro.common.utils.JsonUtils;
 import com.mikuac.shiro.constant.ActionParams;
 import com.mikuac.shiro.dto.action.common.*;
 import com.mikuac.shiro.dto.action.response.*;
@@ -23,6 +24,7 @@ import org.springframework.web.socket.WebSocketSession;
 import java.io.Closeable;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -131,13 +133,13 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<MsgId> sendPrivateMsg(long userId, String msg, boolean autoEscape) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.USER_ID, userId);
         params.put(ActionParams.MESSAGE, msg);
         params.put(ActionParams.AUTO_ESCAPE, autoEscape);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SEND_PRIVATE_MSG, params);
-        return result != null ? result.to(new TypeReference<ActionData<MsgId>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SEND_PRIVATE_MSG, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -150,13 +152,13 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<MsgId> sendPrivateMsg(long userId, List<ArrayMsg> msg, boolean autoEscape) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.USER_ID, userId);
         params.put(ActionParams.MESSAGE, msg);
         params.put(ActionParams.AUTO_ESCAPE, autoEscape);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SEND_PRIVATE_MSG, params);
-        return result != null ? result.to(new TypeReference<ActionData<MsgId>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SEND_PRIVATE_MSG, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -170,14 +172,14 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<MsgId> sendPrivateMsg(long groupId, long userId, String msg, boolean autoEscape) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.USER_ID, userId);
         params.put(ActionParams.MESSAGE, msg);
         params.put(ActionParams.AUTO_ESCAPE, autoEscape);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SEND_PRIVATE_MSG, params);
-        return result != null ? result.to(new TypeReference<ActionData<MsgId>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SEND_PRIVATE_MSG, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -191,14 +193,14 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<MsgId> sendPrivateMsg(long groupId, long userId, List<ArrayMsg> msg, boolean autoEscape) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.USER_ID, userId);
         params.put(ActionParams.MESSAGE, msg);
         params.put(ActionParams.AUTO_ESCAPE, autoEscape);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SEND_PRIVATE_MSG, params);
-        return result != null ? result.to(new TypeReference<ActionData<MsgId>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SEND_PRIVATE_MSG, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -211,13 +213,13 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<MsgId> sendGroupMsg(long groupId, String msg, boolean autoEscape) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.MESSAGE, msg);
         params.put(ActionParams.AUTO_ESCAPE, autoEscape);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SEND_GROUP_MSG, params);
-        return result != null ? result.to(new TypeReference<ActionData<MsgId>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SEND_GROUP_MSG, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -230,13 +232,13 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<MsgId> sendGroupMsg(long groupId, List<ArrayMsg> msg, boolean autoEscape) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.MESSAGE, msg);
         params.put(ActionParams.AUTO_ESCAPE, autoEscape);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SEND_GROUP_MSG, params);
-        return result != null ? result.to(new TypeReference<ActionData<MsgId>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SEND_GROUP_MSG, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -250,14 +252,14 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<MsgId> sendGroupMsg(long groupId, long userId, String msg, boolean autoEscape) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.USER_ID, userId);
         params.put(ActionParams.MESSAGE, msg);
         params.put(ActionParams.AUTO_ESCAPE, autoEscape);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SEND_GROUP_MSG, params);
-        return result != null ? result.to(new TypeReference<ActionData<MsgId>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SEND_GROUP_MSG, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -271,14 +273,14 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<MsgId> sendGroupMsg(long groupId, long userId, List<ArrayMsg> msg, boolean autoEscape) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.USER_ID, userId);
         params.put(ActionParams.MESSAGE, msg);
         params.put(ActionParams.AUTO_ESCAPE, autoEscape);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SEND_GROUP_MSG, params);
-        return result != null ? result.to(new TypeReference<ActionData<MsgId>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SEND_GROUP_MSG, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -293,12 +295,12 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<GuildMemberListResp> getGuildMemberList(String guildId, String nextToken) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GUILD_ID, guildId);
         params.put(ActionParams.NEXT_TOKEN, nextToken);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_GUILD_LIST, params);
-        return result != null ? result.to(new TypeReference<ActionData<GuildMemberListResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_GUILD_LIST, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -311,13 +313,13 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<GuildMsgId> sendGuildMsg(String guildId, String channelId, String msg) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GUILD_ID, guildId);
         params.put(ActionParams.CHANNEL_ID, channelId);
         params.put(ActionParams.MESSAGE, msg);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SEND_GUILD_CHANNEL_MSG, params);
-        return result != null ? result.to(new TypeReference<ActionData<GuildMsgId>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SEND_GUILD_CHANNEL_MSG, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -329,12 +331,12 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<GetGuildMsgResp> getGuildMsg(String guildMsgId, boolean noCache) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.MESSAGE_ID, guildMsgId);
         params.put(ActionParams.NO_CACHE, noCache);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_GUILD_MSG, params);
-        return result != null ? result.to(new TypeReference<ActionData<GetGuildMsgResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_GUILD_MSG, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -344,9 +346,9 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<GuildServiceProfileResp> getGuildServiceProfile() {
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_GUILD_SERVICE_PROFILE, null);
-        return result != null ? result.to(new TypeReference<ActionData<GuildServiceProfileResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_GUILD_SERVICE_PROFILE, null);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -356,9 +358,9 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionList<GuildListResp> getGuildList() {
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_GUILD_LIST, null);
-        return result != null ? result.to(new TypeReference<ActionList<GuildListResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_GUILD_LIST, null);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -369,11 +371,11 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<GuildMetaByGuestResp> getGuildMetaByGuest(String guildId) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GUILD_ID, guildId);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_GUILD_META_BY_GUEST, params);
-        return result != null ? result.to(new TypeReference<ActionData<GuildMetaByGuestResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_GUILD_META_BY_GUEST, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -385,12 +387,12 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionList<ChannelInfoResp> getGuildChannelList(String guildId, boolean noCache) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GUILD_ID, guildId);
         params.put(ActionParams.NO_CACHE, noCache);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_GUILD_CHANNEL_LIST, params);
-        return result != null ? result.to(new TypeReference<ActionList<ChannelInfoResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_GUILD_CHANNEL_LIST, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -402,12 +404,12 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<GuildMemberProfileResp> getGuildMemberProfile(String guildId, String userId) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GUILD_ID, guildId);
         params.put(ActionParams.USER_ID, userId);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_GUILD_MEMBER_PROFILE, params);
-        return result != null ? result.to(new TypeReference<ActionData<GuildMemberProfileResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_GUILD_MEMBER_PROFILE, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -418,11 +420,11 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<GetMsgResp> getMsg(int msgId) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.MESSAGE_ID, msgId);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_MSG, params);
-        return result != null ? result.to(new TypeReference<ActionData<GetMsgResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_MSG, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -433,9 +435,9 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw deleteMsg(int msgId) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.MESSAGE_ID, msgId);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.DELETE_MSG, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.DELETE_MSG, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -449,11 +451,11 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw deleteMsg(long groupId, long userId, int msgId) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.MESSAGE_ID, msgId);
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.USER_ID, userId);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.DELETE_MSG, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.DELETE_MSG, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -467,11 +469,11 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw setGroupKick(long groupId, long userId, boolean rejectAddRequest) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.USER_ID, userId);
         params.put(ActionParams.REJECT_ADD_REQUEST, rejectAddRequest);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SET_GROUP_KICK, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SET_GROUP_KICK, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -485,11 +487,11 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw setGroupBan(long groupId, long userId, int duration) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.USER_ID, userId);
         params.put(ActionParams.DURATION, duration);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SET_GROUP_BAN, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SET_GROUP_BAN, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -502,10 +504,10 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw setGroupWholeBan(long groupId, boolean enable) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.ENABLE, enable);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SET_GROUP_WHOLE_BAN, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SET_GROUP_WHOLE_BAN, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -519,11 +521,11 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw setGroupAdmin(long groupId, long userId, boolean enable) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.USER_ID, userId);
         params.put(ActionParams.ENABLE, enable);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SET_GROUP_ADMIN, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SET_GROUP_ADMIN, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -536,10 +538,10 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw setGroupAnonymous(long groupId, boolean enable) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.ENABLE, enable);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SET_GROUP_ANONYMOUS, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SET_GROUP_ANONYMOUS, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -553,11 +555,11 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw setGroupCard(long groupId, long userId, String card) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.USER_ID, userId);
         params.put(ActionParams.CARD, card);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SET_GROUP_CARD, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SET_GROUP_CARD, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -570,10 +572,10 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw setGroupName(long groupId, String groupName) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.GROUP_NAME, groupName);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SET_GROUP_NAME, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SET_GROUP_NAME, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -586,10 +588,10 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw setGroupLeave(long groupId, boolean isDismiss) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.IS_DISMISS, isDismiss);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SET_GROUP_LEAVE, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SET_GROUP_LEAVE, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -604,12 +606,12 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw setGroupSpecialTitle(long groupId, long userId, String specialTitle, int duration) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.USER_ID, userId);
         params.put(ActionParams.SPECIAL_TITLE, specialTitle);
         params.put(ActionParams.DURATION, duration);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SET_GROUP_SPECIAL_TITLE, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SET_GROUP_SPECIAL_TITLE, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -623,11 +625,11 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw setFriendAddRequest(String flag, boolean approve, String remark) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.FLAG, flag);
         params.put(ActionParams.APPROVE, approve);
         params.put(ActionParams.REMARK, remark);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SET_FRIEND_ADD_REQUEST, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SET_FRIEND_ADD_REQUEST, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -642,12 +644,12 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw setGroupAddRequest(String flag, String subType, boolean approve, String reason) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.FLAG, flag);
         params.put(ActionParams.SUB_TYPE, subType);
         params.put(ActionParams.APPROVE, approve);
         params.put(ActionParams.REASON, reason);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SET_GROUP_ADD_REQUEST, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SET_GROUP_ADD_REQUEST, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -658,9 +660,9 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<LoginInfoResp> getLoginInfo() {
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_LOGIN_INFO, null);
-        return result != null ? result.to(new TypeReference<ActionData<LoginInfoResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_LOGIN_INFO, null);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -672,12 +674,12 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<StrangerInfoResp> getStrangerInfo(long userId, boolean noCache) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.USER_ID, userId);
         params.put(ActionParams.NO_CACHE, noCache);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_STRANGER_INFO, params);
-        return result != null ? result.to(new TypeReference<ActionData<StrangerInfoResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_STRANGER_INFO, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -687,9 +689,9 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionList<FriendInfoResp> getFriendList() {
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_FRIEND_LIST, null);
-        return result != null ? result.to(new TypeReference<ActionList<FriendInfoResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_FRIEND_LIST, null);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -700,9 +702,9 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw deleteFriend(long friendId) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.USER_ID, friendId);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.DELETE_FRIEND, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.DELETE_FRIEND, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -715,12 +717,12 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<GroupInfoResp> getGroupInfo(long groupId, boolean noCache) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.NO_CACHE, noCache);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_GROUP_INFO, params);
-        return result != null ? result.to(new TypeReference<ActionData<GroupInfoResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_GROUP_INFO, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -730,9 +732,9 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionList<GroupInfoResp> getGroupList() {
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_GROUP_LIST, null);
-        return result != null ? result.to(new TypeReference<ActionList<GroupInfoResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_GROUP_LIST, null);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -745,13 +747,13 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<GroupMemberInfoResp> getGroupMemberInfo(long groupId, long userId, boolean noCache) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.USER_ID, userId);
         params.put(ActionParams.NO_CACHE, noCache);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_GROUP_MEMBER_INFO, params);
-        return result != null ? result.to(new TypeReference<ActionData<GroupMemberInfoResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_GROUP_MEMBER_INFO, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -762,11 +764,11 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionList<GroupMemberInfoResp> getGroupMemberList(long groupId) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_GROUP_MEMBER_LIST, params);
-        return result != null ? result.to(new TypeReference<ActionList<GroupMemberInfoResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_GROUP_MEMBER_LIST, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -778,12 +780,12 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionList<GroupMemberInfoResp> getGroupMemberList(long groupId, boolean noCache) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.NO_CACHE, noCache);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_GROUP_MEMBER_LIST, params);
-        return result != null ? result.to(new TypeReference<ActionList<GroupMemberInfoResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_GROUP_MEMBER_LIST, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -794,9 +796,9 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
     @Override
     public ActionData<VersionInfoResp> getVersionInfo() {
 
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_VERSION_INFO, null);
-        return result != null ? result.to(new TypeReference<ActionData<VersionInfoResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_VERSION_INFO, null);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -808,12 +810,12 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<GroupHonorInfoResp> getGroupHonorInfo(long groupId, String type) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.TYPE, type);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_GROUP_HONOR_INFO, params);
-        return result != null ? result.to(new TypeReference<ActionData<GroupHonorInfoResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_GROUP_HONOR_INFO, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -823,9 +825,9 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<BooleanResp> canSendImage() {
-        JSONObject result = actionHandler.action(session, ActionPathEnum.CAN_SEND_IMAGE, null);
-        return result != null ? result.to(new TypeReference<ActionData<BooleanResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.CAN_SEND_IMAGE, null);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -835,9 +837,9 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<BooleanResp> canSendRecord() {
-        JSONObject result = actionHandler.action(session, ActionPathEnum.CAN_SEND_RECORD, null);
-        return result != null ? result.to(new TypeReference<ActionData<BooleanResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.CAN_SEND_RECORD, null);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -851,11 +853,11 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw setGroupPortrait(long groupId, String file, int cache) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.FILE, file);
         params.put(ActionParams.CACHE, cache);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SET_GROUP_PORTRAIT, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SET_GROUP_PORTRAIT, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -868,11 +870,11 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<CheckUrlSafelyResp> checkUrlSafely(String url) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.URL, url);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.CHECK_URL_SAFELY, params);
-        return result != null ? result.to(new TypeReference<ActionData<CheckUrlSafelyResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.CHECK_URL_SAFELY, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -884,10 +886,10 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw sendGroupNotice(long groupId, String content) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.CONTENT, content);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SEN_GROUP_NOTICE, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SEN_GROUP_NOTICE, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -899,11 +901,11 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<GroupAtAllRemainResp> getGroupAtAllRemain(long groupId) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_GROUP_AT_ALL_REMAIN, params);
-        return result != null ? result.to(new TypeReference<ActionData<GroupAtAllRemainResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_GROUP_AT_ALL_REMAIN, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -919,12 +921,12 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw uploadGroupFile(long groupId, String file, String name, String folder) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.FILE, file);
         params.put(ActionParams.NAME, name);
         params.put(ActionParams.FOLDER, folder);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.UPLOAD_GROUP_FILE, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.UPLOAD_GROUP_FILE, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -940,12 +942,11 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw uploadGroupFile(long groupId, String file, String name) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put("file", file);
         params.put(ActionParams.NAME, name);
-
-        JSONObject result = actionHandler.action(session, ActionPathEnum.UPLOAD_GROUP_FILE, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.UPLOAD_GROUP_FILE, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -959,11 +960,11 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw setGroupAnonymousBan(long groupId, Anonymous anonymous, int duration) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.ANONYMOUS, anonymous);
         params.put(ActionParams.DURATION, duration);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SET_GROUP_ANONYMOUS_BAN, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SET_GROUP_ANONYMOUS_BAN, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -977,11 +978,11 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw setGroupAnonymousBan(long groupId, String flag, int duration) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.FLAG, flag);
         params.put(ActionParams.DURATION, duration);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SET_GROUP_ANONYMOUS_BAN, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SET_GROUP_ANONYMOUS_BAN, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -995,13 +996,13 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<DownloadFileResp> downloadFile(String url, int threadCount, String headers) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.URL, url);
         params.put(ActionParams.HEADERS, headers);
         params.put(ActionParams.THREAD_COUNT, threadCount);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.DOWNLOAD_FILE, params);
-        return result != null ? result.to(new TypeReference<ActionData<DownloadFileResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.DOWNLOAD_FILE, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -1012,11 +1013,11 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<DownloadFileResp> downloadFile(String url) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.URL, url);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.DOWNLOAD_FILE, params);
-        return result != null ? result.to(new TypeReference<ActionData<DownloadFileResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.DOWNLOAD_FILE, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
 
     }
 
@@ -1030,12 +1031,12 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<MsgId> sendGroupForwardMsg(long groupId, List<Map<String, Object>> msg) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.MESSAGES, msg);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SEND_GROUP_FORWARD_MSG, params);
-        return result != null ? result.to(new TypeReference<ActionData<MsgId>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SEND_GROUP_FORWARD_MSG, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -1046,11 +1047,11 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<GroupFilesResp> getGroupRootFiles(long groupId) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_GROUP_ROOT_FILES, params);
-        return result != null ? result.to(new TypeReference<ActionData<GroupFilesResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_GROUP_ROOT_FILES, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -1062,12 +1063,12 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<GroupFilesResp> getGroupFilesByFolder(long groupId, String folderId) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.FOLDER_ID, folderId);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_GROUP_FILES_BY_FOLDER, params);
-        return result != null ? result.to(new TypeReference<ActionData<GroupFilesResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_GROUP_FILES_BY_FOLDER, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -1078,11 +1079,11 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionList<EssenceMsgResp> getEssenceMsgList(long groupId) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_ESSENCE_MSG_LIST, params);
-        return result != null ? result.to(new TypeReference<ActionList<EssenceMsgResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_ESSENCE_MSG_LIST, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -1093,9 +1094,9 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw setEssenceMsg(int msgId) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.MESSAGE_ID, msgId);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SET_ESSENCE_MSG, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SET_ESSENCE_MSG, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -1107,9 +1108,9 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw deleteEssenceMsg(int msgId) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.MESSAGE_ID, msgId);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.DELETE_ESSENCE_MSG, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.DELETE_ESSENCE_MSG, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -1125,13 +1126,13 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw setBotProfile(String nickname, String company, String email, String college, String personalNote) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.NICKNAME, nickname);
         params.put(ActionParams.COMPANY, company);
         params.put(ActionParams.EMAIL, email);
         params.put(ActionParams.COLLEGE, college);
         params.put(ActionParams.PERSONAL_NOTE, personalNote);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SET_QQ_PROFILE, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SET_QQ_PROFILE, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -1145,12 +1146,12 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<MsgId> sendPrivateForwardMsg(long userId, List<Map<String, Object>> msg) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.USER_ID, userId);
         params.put(ActionParams.MESSAGES, msg);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SEND_PRIVATE_FORWARD_MSG, params);
-        return result != null ? result.to(new TypeReference<ActionData<MsgId>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SEND_PRIVATE_FORWARD_MSG, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -1163,7 +1164,7 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<MsgId> sendForwardMsg(AnyMessageEvent event, List<Map<String, Object>> msg) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.MESSAGES, msg);
         if (ActionParams.GROUP.equals(event.getMessageType())) {
             params.put(ActionParams.GROUP_ID, event.getGroupId());
@@ -1171,9 +1172,9 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
         if (ActionParams.PRIVATE.equals(event.getMessageType())) {
             params.put(ActionParams.USER_ID, event.getUserId());
         }
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SEND_FORWARD_MSG, params);
-        return result != null ? result.to(new TypeReference<ActionData<MsgId>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SEND_FORWARD_MSG, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -1188,16 +1189,16 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      *                <p>参考 {@link com.mikuac.shiro.common.utils.ShiroUtils#generateSingleMsg(long, String, String)}</p>来生成单条聊天记录
      */
     public ActionData<MsgId> sendGroupForwardMsg(long groupId, List<Map<String, Object>> msg, String prompt, String source, String summary, List<Map<String, String>> news) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.MESSAGES, msg);
         params.put(ActionParams.NEWS, news);
         params.put(ActionParams.PROMPT, prompt);
         params.put(ActionParams.SOURCE, source);
         params.put(ActionParams.SUMMARY, summary);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SEND_GROUP_FORWARD_MSG, params);
-        return result != null ? result.to(new TypeReference<ActionData<MsgId>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SEND_GROUP_FORWARD_MSG, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -1212,16 +1213,16 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      *                <p>参考 {@link com.mikuac.shiro.common.utils.ShiroUtils#generateSingleMsg(long, String, String)}</p>来生成单条聊天记录
      */
     public ActionData<MsgId> sendPrivateForwardMsg(long userId, List<Map<String, Object>> msg, String prompt, String source, String summary, List<Map<String, String>> news) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.USER_ID, userId);
         params.put(ActionParams.MESSAGES, msg);
         params.put(ActionParams.NEWS, news);
         params.put(ActionParams.PROMPT, prompt);
         params.put(ActionParams.SOURCE, source);
         params.put(ActionParams.SUMMARY, summary);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SEND_PRIVATE_FORWARD_MSG, params);
-        return result != null ? result.to(new TypeReference<ActionData<MsgId>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SEND_PRIVATE_FORWARD_MSG, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -1232,11 +1233,11 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<WordSlicesResp> getWordSlices(String content) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.CONTENT, content);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_WORD_SLICES, params);
-        return result != null ? result.to(new TypeReference<ActionData<WordSlicesResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_WORD_SLICES, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -1247,11 +1248,11 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<ClientsResp> getOnlineClients(boolean noCache) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.NO_CACHE, noCache);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_ONLINE_CLIENTS, params);
-        return result != null ? result.to(new TypeReference<ActionData<ClientsResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_ONLINE_CLIENTS, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -1261,11 +1262,11 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      * @return result {@link ActionData} of {@link OcrResp}
      */
     public ActionData<OcrResp> ocrImage(String image) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.IMAGE, image);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.OCR_IMAGE, params);
-        return result != null ? result.to(new TypeReference<ActionData<OcrResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.OCR_IMAGE, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -1278,11 +1279,11 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw uploadPrivateFile(long userId, String file, String name) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.USER_ID, userId);
         params.put(ActionParams.FILE, file);
         params.put(ActionParams.NAME, name);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.UPLOAD_PRIVATE_FILE, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.UPLOAD_PRIVATE_FILE, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -1294,9 +1295,9 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw sendGroupSign(long groupId) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SEND_GROUP_SIGN, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SEND_GROUP_SIGN, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -1308,9 +1309,9 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw deleteUnidirectionalFriend(long userId) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.USER_ID, userId);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.DELETE_UNIDIRECTIONAL_FRIEND, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.DELETE_UNIDIRECTIONAL_FRIEND, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -1321,9 +1322,9 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionList<UnidirectionalFriendListResp> getUnidirectionalFriendList() {
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_UNIDIRECTIONAL_FRIEND_LIST, null);
-        return result != null ? result.to(new TypeReference<ActionList<UnidirectionalFriendListResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_UNIDIRECTIONAL_FRIEND_LIST, null);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -1336,13 +1337,13 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<UrlResp> getGroupFileUrl(long groupId, String fileId, int busId) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.FILE_ID, fileId);
         params.put(ActionParams.BUS_ID, busId);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_GROUP_FILE_URL, params);
-        return result != null ? result.to(new TypeReference<ActionData<UrlResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_GROUP_FILE_URL, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -1355,13 +1356,13 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<GroupFilesResp> getFile(long groupId, String fileId, int busId) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.FILE_ID, fileId);
         params.put(ActionParams.BUS_ID, busId);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_FILE, params);
-        return result != null ? result.to(new TypeReference<ActionData<GroupFilesResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_FILE, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -1373,12 +1374,12 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw createGroupFileFolder(long groupId, String folderName) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.NAME, folderName);
         // 仅能在根目录创建文件夹
         params.put(ActionParams.PARENT_ID, "/");
-        JSONObject result = actionHandler.action(session, ActionPathEnum.CREATE_GROUP_FILE_FOLDER, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.CREATE_GROUP_FILE_FOLDER, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -1391,10 +1392,10 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw deleteGroupFileFolder(long groupId, String folderId) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.FOLDER_ID, folderId);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.DELETE_GROUP_FOLDER, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.DELETE_GROUP_FOLDER, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -1408,11 +1409,11 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw deleteGroupFile(long groupId, String fileId, int busId) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.FILE_ID, fileId);
         params.put(ActionParams.BUS_ID, busId);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.DELETE_GROUP_FILE, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.DELETE_GROUP_FILE, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -1425,10 +1426,10 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw sendLike(long userId, int times) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.USER_ID, userId);
         params.put(ActionParams.TIMES, times);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SEND_LIKE, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SEND_LIKE, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -1438,10 +1439,10 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      * @return result {@link GetStatusResp}
      */
     @Override
-    public GetStatusResp getStatus() {
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_STATUS, null);
-        return result != null ? result.to(new TypeReference<ActionData<GetStatusResp>>() {
-        }).getData() : null;
+    public ActionData<GetStatusResp> getStatus() {
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_STATUS, null);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -1451,9 +1452,9 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionList<String> fetchCustomFace() {
-        JSONObject result = actionHandler.action(session, ActionPathEnum.FETCH_CUSTOM_FACE, null);
-        return result != null ? result.to(new TypeReference<ActionList<String>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.FETCH_CUSTOM_FACE, null);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -1464,11 +1465,11 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<String> sendForwardMsg(List<Map<String, Object>> msg) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.MESSAGES, msg);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SEND_FORWARD_MSG, params);
-        return result != null ? result.to(new TypeReference<ActionData<String>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SEND_FORWARD_MSG, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -1483,14 +1484,14 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
 
     @Override
     public ActionData<GetMsgListResp> getGroupMsgHistory(long groupId, Long messageSeq, int count, boolean reverseOrder) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         if (messageSeq != null) params.put(ActionParams.MESSAGE_SEQ, messageSeq);
         params.put(ActionParams.COUNT, count);
         params.put(ActionParams.REVERSE_ORDER, reverseOrder);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_GROUP_MSG_HISTORY, params);
-        return result != null ? result.to(new TypeReference<ActionData<GetMsgListResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_GROUP_MSG_HISTORY, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
     /**
@@ -1504,20 +1505,20 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionData<GetMsgListResp> getFriendMsgHistory(long userId, Long messageSeq, int count, boolean reverseOrder) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.USER_ID, userId);
         if (messageSeq != null) params.put(ActionParams.MESSAGE_SEQ, messageSeq);
         params.put(ActionParams.COUNT, count);
         params.put(ActionParams.REVERSE_ORDER, reverseOrder);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.GET_FRIEND_MSG_HISTORY, params);
-        return result != null ? result.to(new TypeReference<ActionData<GetMsgListResp>>() {
-        }.getType()) : null;
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_FRIEND_MSG_HISTORY, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
     }
 
-    private ActionRaw doPoke(ActionPathEnum path, Consumer<JSONObject> paramFiller) {
-        JSONObject params = new JSONObject();
+    private ActionRaw doPoke(ActionPathEnum path, Consumer<Map<String, Object>> paramFiller) {
+        Map<String, Object> params = new HashMap<>();
         paramFiller.accept(params);
-        JSONObject result = actionHandler.action(session, path, params);
+        JsonObjectWrapper result = actionHandler.action(session, path, params);
         return result != null
                 ? result.to(ActionRaw.class)
                 : null;
@@ -1556,12 +1557,12 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @Override
     public ActionRaw setGroupReaction(long groupId, int msgId, String code, boolean isAdd) {
-        JSONObject params = new JSONObject();
+        Map<String, Object> params = new HashMap<>();
         params.put(ActionParams.GROUP_ID, groupId);
         params.put(ActionParams.MESSAGE_ID, msgId);
         params.put(ActionParams.CODE, code);
         params.put(ActionParams.IS_ADD, isAdd);
-        JSONObject result = actionHandler.action(session, ActionPathEnum.SET_GROUP_REACTION, params);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SET_GROUP_REACTION, params);
         return result != null ? result.to(ActionRaw.class) : null;
     }
 
@@ -1574,7 +1575,7 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @SuppressWarnings("rawtypes")
     public ActionData customRequest(ActionPath action, Map<String, Object> params) {
-        JSONObject result = actionHandler.action(session, action, params);
+        JsonObjectWrapper result = actionHandler.action(session, action, params);
         return result != null ? result.to(ActionData.class) : null;
     }
 
@@ -1586,9 +1587,13 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      * @return result {@link ActionData}
      */
     public <T> ActionData<T> customRequest(ActionPath action, Map<String, Object> params, Class<T> clazz) {
-        JSONObject result = actionHandler.action(session, action, params);
-        return result != null ? result.to(new TypeReference<>(clazz) {
-        }) : null;
+        JsonObjectWrapper result = actionHandler.action(session, action, params);
+        try {
+            return result != null ? JsonUtils.getObjectMapper().readValue(result.toJSONString(),
+                    JsonUtils.getObjectMapper().getTypeFactory().constructParametricType(ActionData.class, clazz)) : null;
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     /**
@@ -1600,7 +1605,7 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      */
     @SuppressWarnings("rawtypes")
     public ActionData customRawRequest(ActionPath action, Map<String, Object> params) {
-        JSONObject result = actionHandler.rawAction(session, action, params);
+        JsonObjectWrapper result = actionHandler.rawAction(session, action, params);
         return result != null ? result.to(ActionData.class) : null;
     }
 
@@ -1612,9 +1617,13 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
      * @return result {@link ActionData}
      */
     public <T> ActionData<T> customRawRequest(ActionPath action, Map<String, Object> params, Class<T> clazz) {
-        JSONObject result = actionHandler.rawAction(session, action, params);
-        return result != null ? result.to(new TypeReference<>(clazz) {
-        }) : null;
+        JsonObjectWrapper result = actionHandler.rawAction(session, action, params);
+        try {
+            return result != null ? JsonUtils.getObjectMapper().readValue(result.toJSONString(),
+                    JsonUtils.getObjectMapper().getTypeFactory().constructParametricType(ActionData.class, clazz)) : null;
+        } catch (Exception e) {
+            return null;
+        }
     }
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/common/ActionData.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/common/ActionData.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.common;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 /**
@@ -12,13 +12,13 @@ import lombok.Data;
 @Data
 public class ActionData<T> {
 
-    @JSONField(name = "status")
+    @JsonProperty("status")
     private String status;
 
-    @JSONField(name = "retcode")
+    @JsonProperty("retcode")
     private Integer retCode;
 
-    @JSONField(name = "data")
+    @JsonProperty("data")
     private T data;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/common/ActionList.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/common/ActionList.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.common;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.util.List;
@@ -14,13 +14,13 @@ import java.util.List;
 @Data
 public class ActionList<T> {
 
-    @JSONField(name = "status")
+    @JsonProperty("status")
     private String status;
 
-    @JSONField(name = "retcode")
+    @JsonProperty("retcode")
     private Integer retCode;
 
-    @JSONField(name = "data")
+    @JsonProperty("data")
     private List<T> data;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/common/ActionRaw.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/common/ActionRaw.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.common;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 /**
@@ -12,13 +12,13 @@ import lombok.Data;
 @Data
 public class ActionRaw {
 
-    @JSONField(name = "status")
+    @JsonProperty("status")
     private String status;
 
-    @JSONField(name = "retcode")
+    @JsonProperty("retcode")
     private Integer retCode;
 
-    @JSONField(name = "echo")
+    @JsonProperty("echo")
     private Long echo;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/common/Anonymous.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/common/Anonymous.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.common;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 /**
@@ -12,13 +12,13 @@ import lombok.Data;
 @Data
 public class Anonymous {
 
-    @JSONField(name = "id")
+    @JsonProperty("id")
     private Long id;
 
-    @JSONField(name = "name")
+    @JsonProperty("name")
     private String name;
 
-    @JSONField(name = "flag")
+    @JsonProperty("flag")
     private String flag;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/common/GuildMsgId.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/common/GuildMsgId.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.common;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 /**
@@ -12,7 +12,7 @@ import lombok.Data;
 @Data
 public class GuildMsgId {
 
-    @JSONField(name = "message_id")
+    @JsonProperty("message_id")
     private String messageId;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/common/MsgId.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/common/MsgId.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.common;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 /**
@@ -12,7 +12,7 @@ import lombok.Data;
 @Data
 public class MsgId {
 
-    @JSONField(name = "message_id")
+    @JsonProperty("message_id")
     private Integer messageId;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/BooleanResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/BooleanResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 /**
@@ -12,7 +12,7 @@ import lombok.Data;
 @Data
 public class BooleanResp {
 
-    @JSONField(name = "yes")
+    @JsonProperty("yes")
     private Boolean yes;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/ChannelInfoResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/ChannelInfoResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.util.List;
@@ -17,61 +17,61 @@ public class ChannelInfoResp {
     /**
      * 所属频道ID
      */
-    @JSONField(name = "owner_guild_id")
+    @JsonProperty("owner_guild_id")
     private String ownerGuildId;
 
     /**
      * 子频道ID
      */
-    @JSONField(name = "channel_id")
+    @JsonProperty("channel_id")
     private String channelId;
 
     /**
      * 子频道类型
      */
-    @JSONField(name = "channel_type")
+    @JsonProperty("channel_type")
     private Integer channelType;
 
     /**
      * 子频道名称
      */
-    @JSONField(name = "channel_name")
+    @JsonProperty("channel_name")
     private String channelName;
 
     /**
      * 创建时间
      */
-    @JSONField(name = "create_time")
+    @JsonProperty("create_time")
     private Long createTime;
 
     /**
      * 创建者ID
      */
-    @JSONField(name = "creator_tiny_id")
+    @JsonProperty("creator_tiny_id")
     private String creatorTinyId;
 
     /**
      * 发言权限类型
      */
-    @JSONField(name = "talk_permission")
+    @JsonProperty("talk_permission")
     private Integer talkPermission;
 
     /**
      * 可视性类型
      */
-    @JSONField(name = "visible_type")
+    @JsonProperty("visible_type")
     private Integer visibleType;
 
     /**
      * 当前启用的慢速模式Key
      */
-    @JSONField(name = "current_slow_mode")
+    @JsonProperty("current_slow_mode")
     private Integer currentSlowMode;
 
     /**
      * 频道内可用慢速模式类型列表
      */
-    @JSONField(name = "slow_modes")
+    @JsonProperty("slow_modes")
     private List<SlowModeInfo> slowModes;
 
     @Data
@@ -80,25 +80,25 @@ public class ChannelInfoResp {
         /**
          * 慢速模式Key
          */
-        @JSONField(name = "slow_mode_key")
+        @JsonProperty("slow_mode_key")
         private Integer slowModeKey;
 
         /**
          * 慢速模式说明
          */
-        @JSONField(name = "slow_mode_text")
+        @JsonProperty("slow_mode_text")
         private String slowModeText;
 
         /**
          * 周期内发言频率限制
          */
-        @JSONField(name = "speak_frequency")
+        @JsonProperty("speak_frequency")
         private Integer speakFrequency;
 
         /**
          * 单位周期时间, 单位秒
          */
-        @JSONField(name = "slow_mode_circle")
+        @JsonProperty("slow_mode_circle")
         private Integer slowModeCircle;
 
     }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/CheckUrlSafelyResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/CheckUrlSafelyResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 /**
@@ -12,7 +12,7 @@ import lombok.Data;
 @Data
 public class CheckUrlSafelyResp {
 
-    @JSONField(name = "level")
+    @JsonProperty("level")
     private Integer level;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/ClientsResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/ClientsResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.util.List;
@@ -14,19 +14,19 @@ import java.util.List;
 @Data
 public class ClientsResp {
 
-    @JSONField(name = "clients")
+    @JsonProperty("clients")
     private List<Clients> clients;
 
     @Data
     private static class Clients {
 
-        @JSONField(name = "app_id")
+        @JsonProperty("app_id")
         private Long appId;
 
-        @JSONField(name = "device_name")
+        @JsonProperty("device_name")
         private String deviceName;
 
-        @JSONField(name = "device_kind")
+        @JsonProperty("device_kind")
         private String deviceKind;
 
     }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/DownloadFileResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/DownloadFileResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 /**
@@ -12,7 +12,7 @@ import lombok.Data;
 @Data
 public class DownloadFileResp {
 
-    @JSONField(name = "file")
+    @JsonProperty("file")
     private String file;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/EssenceMsgResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/EssenceMsgResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 /**
@@ -12,25 +12,25 @@ import lombok.Data;
 @Data
 public class EssenceMsgResp {
 
-    @JSONField(name = "sender_id")
+    @JsonProperty("sender_id")
     private Long senderId;
 
-    @JSONField(name = "sender_nick")
+    @JsonProperty("sender_nick")
     private String senderNick;
 
-    @JSONField(name = "sender_time")
+    @JsonProperty("sender_time")
     private Long senderTime;
 
-    @JSONField(name = "operator_id")
+    @JsonProperty("operator_id")
     private Long operatorId;
 
-    @JSONField(name = "operator_nick")
+    @JsonProperty("operator_nick")
     private String operatorNick;
 
-    @JSONField(name = "operator_time")
+    @JsonProperty("operator_time")
     private String operatorTime;
 
-    @JSONField(name = "message_id")
+    @JsonProperty("message_id")
     private Integer messageId;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/FriendInfoResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/FriendInfoResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 /**
@@ -12,13 +12,13 @@ import lombok.Data;
 @Data
 public class FriendInfoResp {
 
-    @JSONField(name = "user_id")
+    @JsonProperty("user_id")
     private Long userId;
 
-    @JSONField(name = "nickname")
+    @JsonProperty("nickname")
     private String nickname;
 
-    @JSONField(name = "remark")
+    @JsonProperty("remark")
     private String remark;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/GetGuildMsgResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/GetGuildMsgResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mikuac.shiro.dto.event.message.GuildMessageEvent;
 import lombok.Data;
 
@@ -13,28 +13,28 @@ import lombok.Data;
 @Data
 public class GetGuildMsgResp {
 
-    @JSONField(name = "guild_id")
+    @JsonProperty("guild_id")
     private String guildId;
 
-    @JSONField(name = "channel_id")
+    @JsonProperty("channel_id")
     private String channelId;
 
-    @JSONField(name = "message")
+    @JsonProperty("message")
     private String message;
 
-    @JSONField(name = "message_id")
+    @JsonProperty("message_id")
     private String messageId;
 
-    @JSONField(name = "message_seq")
+    @JsonProperty("message_seq")
     private Integer messageSeq;
 
-    @JSONField(name = "message_source")
+    @JsonProperty("message_source")
     private String messageSource;
 
-    @JSONField(name = "sender")
+    @JsonProperty("sender")
     private GuildMessageEvent.Sender sender;
 
-    @JSONField(name = "time")
+    @JsonProperty("time")
     private Long time;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/GetMsgListResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/GetMsgListResp.java
@@ -1,12 +1,20 @@
 package com.mikuac.shiro.dto.action.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
 public class GetMsgListResp {
+
+    @JsonProperty("status")
     private String status;
+
+    @JsonProperty("retcode")
     private int retcode;
+
+    @JsonProperty("messages")
     private List<GetMsgResp> messages;
+
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/GetMsgResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/GetMsgResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 /**
@@ -15,43 +15,43 @@ public class GetMsgResp {
     /**
      * 消息id
      */
-    @JSONField(name = "message_id")
+    @JsonProperty("message_id")
     private Integer messageId;
 
     /**
      * 消息真实id
      */
-    @JSONField(name = "real_id")
+    @JsonProperty("real_id")
     private Integer realId;
 
     /**
      * 发送者
      */
-    @JSONField(name = "sender")
+    @JsonProperty("sender")
     private Sender sender;
 
     /**
      * 发送时间
      */
-    @JSONField(name = "time")
+    @JsonProperty("time")
     private Integer time;
 
     /**
      * 消息内容
      */
-    @JSONField(name = "message")
+    @JsonProperty("message")
     private String message;
 
     /**
      * 原始消息内容
      */
-    @JSONField(name = "raw_message")
+    @JsonProperty("raw_message")
     private String rawMessage;
 
     /**
      * 消息类型
      */
-    @JSONField(name = "message_type")
+    @JsonProperty("message_type")
     private String messageType;
 
     /**
@@ -60,31 +60,31 @@ public class GetMsgResp {
     @Data
     public static class Sender {
 
-        @JSONField(name = "user_id")
+        @JsonProperty("user_id")
         private String userId;
 
-        @JSONField(name = "nickname")
+        @JsonProperty("nickname")
         private String nickname;
 
-        @JSONField(name = "card")
+        @JsonProperty("card")
         private String card;
 
-        @JSONField(name = "sex")
+        @JsonProperty("sex")
         private String sex;
 
-        @JSONField(name = "age")
+        @JsonProperty("age")
         private Integer age;
 
-        @JSONField(name = "area")
+        @JsonProperty("area")
         private String area;
 
-        @JSONField(name = "level")
+        @JsonProperty("level")
         private String level;
 
-        @JSONField(name = "role")
+        @JsonProperty("role")
         private String role;
 
-        @JSONField(name = "title")
+        @JsonProperty("title")
         private String title;
 
     }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/GetStatusResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/GetStatusResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 /**
@@ -13,25 +13,25 @@ public class GetStatusResp {
     /**
      * 原 CQHTTP 字段, 恒定为 true
      */
-    @JSONField(name = "app_initialized")
+    @JsonProperty("app_initialized")
     private Boolean appInitialized;
 
     /**
      * 原 CQHTTP 字段, 恒定为 true
      */
-    @JSONField(name = "app_enabled")
+    @JsonProperty("app_enabled")
     private Boolean appEnabled;
 
     /**
      * 原 CQHTTP 字段
      */
-    @JSONField(name = "plugins_good")
+    @JsonProperty("plugins_good")
     private Boolean pluginsGood;
 
     /**
      * 原 CQHTTP 字段, 恒定为 true
      */
-    @JSONField(name = "app_good")
+    @JsonProperty("app_good")
     private Boolean appGood;
 
     /**
@@ -55,49 +55,49 @@ public class GetStatusResp {
         /**
          * 收到的数据包总数
          */
-        @JSONField(name = "packet_received")
+        @JsonProperty("packet_received")
         private Long packetReceived;
 
         /**
          * 发送的数据包总数
          */
-        @JSONField(name = "packet_sent")
+        @JsonProperty("packet_sent")
         private Long packetSent;
 
         /**
          * 数据包丢失总数
          */
-        @JSONField(name = "packet_lost")
+        @JsonProperty("packet_lost")
         private Integer packetLost;
 
         /**
          * 接受信息总数
          */
-        @JSONField(name = "message_received")
+        @JsonProperty("message_received")
         private Long messageReceived;
 
         /**
          * 发送信息总数
          */
-        @JSONField(name = "message_sent")
+        @JsonProperty("message_sent")
         private Long messageSent;
 
         /**
          * TCP 链接断开次数
          */
-        @JSONField(name = "disconnect_times")
+        @JsonProperty("disconnect_times")
         private Integer disconnectTimes;
 
         /**
          * 账号掉线次数
          */
-        @JSONField(name = "lost_times")
+        @JsonProperty("lost_times")
         private Integer lostTimes;
 
         /**
          * 最后一条消息时间
          */
-        @JSONField(name = "last_message_time")
+        @JsonProperty("last_message_time")
         private Long lastMessageTime;
     }
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/GroupAtAllRemainResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/GroupAtAllRemainResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 /**
@@ -15,19 +15,19 @@ public class GroupAtAllRemainResp {
     /**
      * 是否可以 @全体成员
      */
-    @JSONField(name = "can_at_all")
+    @JsonProperty("can_at_all")
     private Boolean canAtAll;
 
     /**
      * 群内所有管理当天剩余 @全体成员 次数
      */
-    @JSONField(name = "remain_at_all_count_for_group")
+    @JsonProperty("remain_at_all_count_for_group")
     private Integer remainAtAllCountForGroup;
 
     /**
      * Bot 当天剩余 @全体成员 次数
      */
-    @JSONField(name = "remain_at_all_count_for_uin")
+    @JsonProperty("remain_at_all_count_for_uin")
     private Integer remainAtAllCountForUin;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/GroupFilesResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/GroupFilesResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.util.List;
@@ -21,16 +21,16 @@ public class GroupFilesResp {
     /**
      * 仅适用于LLOneBot
      */
-    @JSONField(name = "base64")
+    @JsonProperty("base64")
     private String base64;
 
-    @JSONField(name = "file")
+    @JsonProperty("file")
     private String file;
 
-    @JSONField(name = "file_name")
+    @JsonProperty("file_name")
     private String fileName;
 
-    @JSONField(name = "file_size")
+    @JsonProperty("file_size")
     private Long fileSize;
 
     /**
@@ -39,34 +39,34 @@ public class GroupFilesResp {
     @Data
     public static class Files {
 
-        @JSONField(name = "file_id")
+        @JsonProperty("file_id")
         private String fileId;
 
-        @JSONField(name = "file_name")
+        @JsonProperty("file_name")
         private String fileName;
 
-        @JSONField(name = "busid")
+        @JsonProperty("busid")
         private Integer busId;
 
-        @JSONField(name = "file_size")
+        @JsonProperty("file_size")
         private Long fileSize;
 
-        @JSONField(name = "upload_time")
+        @JsonProperty("upload_time")
         private Long uploadTime;
 
-        @JSONField(name = "dead_time")
+        @JsonProperty("dead_time")
         private Long deadTime;
 
-        @JSONField(name = "modify_time")
+        @JsonProperty("modify_time")
         private Long modifyTime;
 
-        @JSONField(name = "download_times")
+        @JsonProperty("download_times")
         private Integer downloadTimes;
 
-        @JSONField(name = "uploader")
+        @JsonProperty("uploader")
         private Long uploader;
 
-        @JSONField(name = "uploader_name")
+        @JsonProperty("uploader_name")
         private String uploaderName;
 
     }
@@ -77,22 +77,22 @@ public class GroupFilesResp {
     @Data
     public static class Folders {
 
-        @JSONField(name = "folder_id")
+        @JsonProperty("folder_id")
         private String folderId;
 
-        @JSONField(name = "folder_name")
+        @JsonProperty("folder_name")
         private String folderName;
 
-        @JSONField(name = "create_time")
+        @JsonProperty("create_time")
         private Long createTime;
 
-        @JSONField(name = "creator")
+        @JsonProperty("creator")
         private Long creator;
 
-        @JSONField(name = "creator_name")
+        @JsonProperty("creator_name")
         private String creatorName;
 
-        @JSONField(name = "total_file_count")
+        @JsonProperty("total_file_count")
         private Integer totalFileCount;
 
     }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/GroupHonorInfoResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/GroupHonorInfoResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.util.List;
@@ -14,25 +14,25 @@ import java.util.List;
 @Data
 public class GroupHonorInfoResp {
 
-    @JSONField(name = "group_id")
+    @JsonProperty("group_id")
     private Long groupId;
 
-    @JSONField(name = "current_talkative")
+    @JsonProperty("current_talkative")
     private CurrentTalkative currentTalkative;
 
-    @JSONField(name = "talkative_list")
+    @JsonProperty("talkative_list")
     private List<OtherHonor> talkativeList;
 
-    @JSONField(name = "performer_list")
+    @JsonProperty("performer_list")
     private List<OtherHonor> performerList;
 
-    @JSONField(name = "legend_list")
+    @JsonProperty("legend_list")
     private List<OtherHonor> legendList;
 
-    @JSONField(name = "strong_newbie_list")
+    @JsonProperty("strong_newbie_list")
     private List<OtherHonor> strongNewbieList;
 
-    @JSONField(name = "emotion_list")
+    @JsonProperty("emotion_list")
     private List<OtherHonor> emotionList;
 
     /**
@@ -41,16 +41,16 @@ public class GroupHonorInfoResp {
     @Data
     public static class CurrentTalkative {
 
-        @JSONField(name = "user_id")
+        @JsonProperty("user_id")
         private Long userId;
 
-        @JSONField(name = "nickname")
+        @JsonProperty("nickname")
         private String nickname;
 
-        @JSONField(name = "avatar")
+        @JsonProperty("avatar")
         private String avatar;
 
-        @JSONField(name = "day_count")
+        @JsonProperty("day_count")
         private Integer dayCount;
 
     }
@@ -61,16 +61,16 @@ public class GroupHonorInfoResp {
     @Data
     public static class OtherHonor {
 
-        @JSONField(name = "user_id")
+        @JsonProperty("user_id")
         private Long userId;
 
-        @JSONField(name = "nickname")
+        @JsonProperty("nickname")
         private String nickname;
 
-        @JSONField(name = "avatar")
+        @JsonProperty("avatar")
         private String avatar;
 
-        @JSONField(name = "description")
+        @JsonProperty("description")
         private String description;
 
     }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/GroupInfoExResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/GroupInfoExResp.java
@@ -1,84 +1,84 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 @Data
 public class GroupInfoExResp {
 
-    @JSONField(name = "groupCode")
+    @JsonProperty("groupCode")
     private long groupCode;// 群号
 
-    @JSONField(name = "resultCode")
+    @JsonProperty("resultCode")
     private long resultCode;// 结果码
 
-    @JSONField(name = "extInfo")
+    @JsonProperty("extInfo")
     private ExtInfo extInfo;// 扩展信息
 
     @Data
     public static class ExtInfo {
 
-        @JSONField(name = "groupInfoExtSeq")
+        @JsonProperty("groupInfoExtSeq")
         private long groupInfoExtSeq;// 群信息序列号
 
-        @JSONField(name = "reserve")
+        @JsonProperty("reserve")
         private int reserve;//?
 
-        @JSONField(name = "luckyWordId")
+        @JsonProperty("luckyWordId")
         private int luckyWordId;// 幸运字符ID
 
-        @JSONField(name = "lightCharNum")
+        @JsonProperty("lightCharNum")
         private int lightCharNum;//?
 
-        @JSONField(name = "luckyWord")
+        @JsonProperty("luckyWord")
         private String luckyWord;// 幸运字符
 
-        @JSONField(name = "starId")
+        @JsonProperty("starId")
         private long starId;//?
 
-        @JSONField(name = "essentialMsgSwitch")
+        @JsonProperty("essentialMsgSwitch")
         private int essentialMsgSwitch;// 精华消息开关
 
-        @JSONField(name = "todoSeq")
+        @JsonProperty("todoSeq")
         private long todoSeq;//?
 
-        @JSONField(name = "blacklistExpireTime")
+        @JsonProperty("blacklistExpireTime")
         private long blacklistExpireTime;// 黑名单过期时间
 
-        @JSONField(name = "isLimitGroupRtc")
+        @JsonProperty("isLimitGroupRtc")
         private int isLimitGroupRtc;// 是否限制群视频通话
 
-        @JSONField(name = "companyId")
+        @JsonProperty("companyId")
         private long companyId;// 公司ID
 
-        @JSONField(name = "hasGroupCustomPortrait")
+        @JsonProperty("hasGroupCustomPortrait")
         private int hasGroupCustomPortrait;// 是否有群自定义头像
 
-        @JSONField(name = "bindGuildId")
+        @JsonProperty("bindGuildId")
         private long bindGuildId;// 绑定频道ID？
 
-        @JSONField(name = "groupOwnerId")
+        @JsonProperty("groupOwnerId")
         private GroupOwner groupOwnerId;// 群主信息
 
-        @JSONField(name = "essentialMsgPrivilege")
+        @JsonProperty("essentialMsgPrivilege")
         private int essentialMsgPrivilege;// 精华消息权限
 
-        @JSONField(name = "msgEventSeq")
+        @JsonProperty("msgEventSeq")
         private String msgEventSeq;// 消息事件序列号
 
-        @JSONField(name = "inviteRobotSwitch")
+        @JsonProperty("inviteRobotSwitch")
         private int inviteRobotSwitch;// 邀请机器人开关
 
-        @JSONField(name = "gangUpId")
+        @JsonProperty("gangUpId")
         private String gangUpId;//?
 
-        @JSONField(name = "qqMusicMedalSwitch")
+        @JsonProperty("qqMusicMedalSwitch")
         private int qqMusicMedalSwitch;// QQ音乐勋章开关
 
-        @JSONField(name = "showPlayTogetherSwitch")
+        @JsonProperty("showPlayTogetherSwitch")
         private int showPlayTogetherSwitch;// 显示一起玩开关
 
-        @JSONField(name = "groupFlagPro1")
+        @JsonProperty("groupFlagPro1")
         private String groupFlagPro1;// 群标识1
 
     }
@@ -86,13 +86,13 @@ public class GroupInfoExResp {
     @Data
     public static class GroupOwner {
 
-        @JSONField(name = "memberUin")// QQ号
+        @JsonProperty("memberUin")// QQ号
         private long memberUin;
 
-        @JSONField(name = "memberUid")// UID
+        @JsonProperty("memberUid")// UID
         private String memberUid;
 
-        @JSONField(name = "memberQid")// QID
+        @JsonProperty("memberQid")// QID
         private String memberQid;
     }
 

--- a/src/main/java/com/mikuac/shiro/dto/action/response/GroupInfoResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/GroupInfoResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 /**
@@ -12,25 +12,25 @@ import lombok.Data;
 @Data
 public class GroupInfoResp {
 
-    @JSONField(name = "group_id")
+    @JsonProperty("group_id")
     private Long groupId;
 
-    @JSONField(name = "group_name")
+    @JsonProperty("group_name")
     private String groupName;
 
-    @JSONField(name = "group_memo")
+    @JsonProperty("group_memo")
     private String groupMemo;
 
-    @JSONField(name = "group_create_time")
+    @JsonProperty("group_create_time")
     private Integer groupCreateTime;
 
-    @JSONField(name = "group_level")
+    @JsonProperty("group_level")
     private Integer groupLevel;
 
-    @JSONField(name = "member_count")
+    @JsonProperty("member_count")
     private Integer memberCount;
 
-    @JSONField(name = "max_member_count")
+    @JsonProperty("max_member_count")
     private Integer maxMemberCount;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/GroupMemberInfoResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/GroupMemberInfoResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 /**
@@ -12,49 +12,49 @@ import lombok.Data;
 @Data
 public class GroupMemberInfoResp {
 
-    @JSONField(name = "group_id")
+    @JsonProperty("group_id")
     private Long groupId;
 
-    @JSONField(name = "user_id")
+    @JsonProperty("user_id")
     private Long userId;
 
-    @JSONField(name = "nickname")
+    @JsonProperty("nickname")
     private String nickname;
 
-    @JSONField(name = "card")
+    @JsonProperty("card")
     private String card;
 
-    @JSONField(name = "sex")
+    @JsonProperty("sex")
     private String sex;
 
-    @JSONField(name = "age")
+    @JsonProperty("age")
     private Integer age;
 
-    @JSONField(name = "area")
+    @JsonProperty("area")
     private String area;
 
-    @JSONField(name = "join_time")
+    @JsonProperty("join_time")
     private Integer joinTime;
 
-    @JSONField(name = "last_sent_time")
+    @JsonProperty("last_sent_time")
     private Integer lastSentTime;
 
-    @JSONField(name = "level")
+    @JsonProperty("level")
     private String level;
 
-    @JSONField(name = "role")
+    @JsonProperty("role")
     private String role;
 
-    @JSONField(name = "unfriendly")
+    @JsonProperty("unfriendly")
     private Boolean unfriendly;
 
-    @JSONField(name = "title")
+    @JsonProperty("title")
     private String title;
 
-    @JSONField(name = "title_expire_time")
+    @JsonProperty("title_expire_time")
     private Long titleExpireTime;
 
-    @JSONField(name = "card_changeable")
+    @JsonProperty("card_changeable")
     private Boolean cardChangeable;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/GuildListResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/GuildListResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 /**
@@ -12,13 +12,13 @@ import lombok.Data;
 @Data
 public class GuildListResp {
 
-    @JSONField(name = "guild_id")
+    @JsonProperty("guild_id")
     private String guildId;
 
-    @JSONField(name = "guild_name")
+    @JsonProperty("guild_name")
     private String guildName;
 
-    @JSONField(name = "guild_display_id")
+    @JsonProperty("guild_display_id")
     private Long guildDisplayId;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/GuildMemberListResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/GuildMemberListResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.util.List;
@@ -17,19 +17,19 @@ public class GuildMemberListResp {
     /**
      * 成员列表
      */
-    @JSONField(name = "members")
+    @JsonProperty("members")
     private List<GuildMemberInfo> members;
 
     /**
      * 是否最终页
      */
-    @JSONField(name = "finished")
+    @JsonProperty("finished")
     private Boolean finished;
 
     /**
      * 翻页Token
      */
-    @JSONField(name = "next_token")
+    @JsonProperty("next_token")
     private String nextToken;
 
     @Data
@@ -38,19 +38,19 @@ public class GuildMemberListResp {
         /**
          * 成员ID
          */
-        @JSONField(name = "tiny_id")
+        @JsonProperty("tiny_id")
         private String tinyId;
 
         /**
          * 成员昵称
          */
-        @JSONField(name = "nickname")
+        @JsonProperty("nickname")
         private String nickname;
 
         /**
          * 成员头衔
          */
-        @JSONField(name = "title")
+        @JsonProperty("title")
         private String title;
 
         /**
@@ -58,13 +58,13 @@ public class GuildMemberListResp {
          * 默认情况下频道管理员的权限组ID为 2, 部分频道可能会另行创建, 需手动判断
          * 此接口仅展现最新的权限组, 获取用户加入的所有权限组请使用 get_guild_member_profile 接口
          */
-        @JSONField(name = "role_id")
+        @JsonProperty("role_id")
         private String roleId;
 
         /**
          * 所在权限组名称
          */
-        @JSONField(name = "role_name")
+        @JsonProperty("role_name")
         private String roleName;
 
     }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/GuildMemberProfileResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/GuildMemberProfileResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.util.List;
@@ -14,28 +14,28 @@ import java.util.List;
 @Data
 public class GuildMemberProfileResp {
 
-    @JSONField(name = "tiny_id")
+    @JsonProperty("tiny_id")
     private String tinyId;
 
-    @JSONField(name = "nickname")
+    @JsonProperty("nickname")
     private String nickname;
 
-    @JSONField(name = "avatar_url")
+    @JsonProperty("avatar_url")
     private String avatarUrl;
 
-    @JSONField(name = "join_time")
+    @JsonProperty("join_time")
     private Long joinTime;
 
-    @JSONField(name = "roles")
+    @JsonProperty("roles")
     private List<RoleInfo> roles;
 
     @Data
     private static class RoleInfo {
 
-        @JSONField(name = "role_id")
+        @JsonProperty("role_id")
         private String roleId;
 
-        @JSONField(name = "role_name")
+        @JsonProperty("role_name")
         private String roleName;
 
     }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/GuildMetaByGuestResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/GuildMetaByGuestResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 /**
@@ -12,31 +12,31 @@ import lombok.Data;
 @Data
 public class GuildMetaByGuestResp {
 
-    @JSONField(name = "guild_id")
+    @JsonProperty("guild_id")
     private String guildId;
 
-    @JSONField(name = "guild_name")
+    @JsonProperty("guild_name")
     private String guildName;
 
-    @JSONField(name = "guild_profile")
+    @JsonProperty("guild_profile")
     private String guildProfile;
 
-    @JSONField(name = "create_time")
+    @JsonProperty("create_time")
     private Long createTime;
 
-    @JSONField(name = "max_member_count")
+    @JsonProperty("max_member_count")
     private Long maxMemberCount;
 
-    @JSONField(name = "max_robot_count")
+    @JsonProperty("max_robot_count")
     private Long maxRobotCount;
 
-    @JSONField(name = "max_admin_count")
+    @JsonProperty("max_admin_count")
     private Long maxAdminCount;
 
-    @JSONField(name = "member_count")
+    @JsonProperty("member_count")
     private Long memberCount;
 
-    @JSONField(name = "owner_id")
+    @JsonProperty("owner_id")
     private String ownerId;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/GuildServiceProfileResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/GuildServiceProfileResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 /**
@@ -12,13 +12,13 @@ import lombok.Data;
 @Data
 public class GuildServiceProfileResp {
 
-    @JSONField(name = "nickname")
+    @JsonProperty("nickname")
     private String nickname;
 
-    @JSONField(name = "tiny_id")
+    @JsonProperty("tiny_id")
     private String tinyId;
 
-    @JSONField(name = "avatar_url")
+    @JsonProperty("avatar_url")
     private String avatarUrl;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/LoginInfoResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/LoginInfoResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 /**
@@ -12,10 +12,10 @@ import lombok.Data;
 @Data
 public class LoginInfoResp {
 
-    @JSONField(name = "user_id")
+    @JsonProperty("user_id")
     private Long userId;
 
-    @JSONField(name = "nickname")
+    @JsonProperty("nickname")
     private String nickname;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/OcrResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/OcrResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.util.List;
@@ -14,10 +14,10 @@ import java.util.List;
 @Data
 public class OcrResp {
 
-    @JSONField(name = "texts")
+    @JsonProperty("texts")
     private List<TextDetection> texts;
 
-    @JSONField(name = "language")
+    @JsonProperty("language")
     private String language;
 
     @Data
@@ -26,19 +26,19 @@ public class OcrResp {
         /**
          * 文本
          */
-        @JSONField(name = "text")
+        @JsonProperty("text")
         private String text;
 
         /**
          * 置信度
          */
-        @JSONField(name = "confidence")
+        @JsonProperty("confidence")
         private Integer confidence;
 
         /**
          * 坐标
          */
-        @JSONField(name = "coordinates")
+        @JsonProperty("coordinates")
         private List<Coordinate> coordinates;
 
     }
@@ -46,10 +46,10 @@ public class OcrResp {
     @Data
     private static class Coordinate {
 
-        @JSONField(name = "x")
+        @JsonProperty("x")
         private Long x;
 
-        @JSONField(name = "y")
+        @JsonProperty("y")
         private Long y;
 
     }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/StrangerInfoResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/StrangerInfoResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 /**
@@ -15,43 +15,43 @@ public class StrangerInfoResp {
     /**
      * QQ 号
      */
-    @JSONField(name = "user_id")
+    @JsonProperty("user_id")
     private Long userId;
 
     /**
      * 昵称
      */
-    @JSONField(name = "nickname")
+    @JsonProperty("nickname")
     private String nickname;
 
     /**
      * 性别 male 或 female 或 unknown
      */
-    @JSONField(name = "sex")
+    @JsonProperty("sex")
     private String sex;
 
     /**
      * 年龄
      */
-    @JSONField(name = "age")
+    @JsonProperty("age")
     private Integer age;
 
     /**
      * qid id 身份卡
      */
-    @JSONField(name = "qid")
+    @JsonProperty("qid")
     private String qid;
 
     /**
      * 等级
      */
-    @JSONField(name = "level")
+    @JsonProperty("level")
     private Integer level;
 
     /**
      * 在线天数？我猜的（
      */
-    @JSONField(name = "login_days")
+    @JsonProperty("login_days")
     private Integer loginDays;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/UnidirectionalFriendListResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/UnidirectionalFriendListResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 /**
@@ -12,13 +12,13 @@ import lombok.Data;
 @Data
 public class UnidirectionalFriendListResp {
 
-    @JSONField(name = "user_id")
+    @JsonProperty("user_id")
     private Long userId;
 
-    @JSONField(name = "nickname")
+    @JsonProperty("nickname")
     private String nickname;
 
-    @JSONField(name = "source")
+    @JsonProperty("source")
     private String source;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/UrlResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/UrlResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 /**
@@ -12,7 +12,7 @@ import lombok.Data;
 @Data
 public class UrlResp {
 
-    @JSONField(name = "url")
+    @JsonProperty("url")
     private String url;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/VersionInfoResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/VersionInfoResp.java
@@ -1,20 +1,20 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 @Data
 public class VersionInfoResp {
 
-    @JSONField(name = "app_name")
+    @JsonProperty("app_name")
     private String appName;
 
-    @JSONField(name = "app_version")
+    @JsonProperty("app_version")
     private String appVersion;
 
-    @JSONField(name = "protocol_version")
+    @JsonProperty("protocol_version")
     private String protocolVersion;
 
-    @JSONField(name = "version")
+    @JsonProperty("version")
     private String version;
 }

--- a/src/main/java/com/mikuac/shiro/dto/action/response/WordSlicesResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/WordSlicesResp.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.action.response;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.util.List;
@@ -14,7 +14,7 @@ import java.util.List;
 @Data
 public class WordSlicesResp {
 
-    @JSONField(name = "slices")
+    @JsonProperty("slices")
     private List<String> slices;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/Event.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/Event.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -18,13 +18,13 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder(toBuilder = true)
 public class Event {
 
-    @JSONField(name = "post_type")
+    @JsonProperty("post_type")
     private String postType;
 
-    @JSONField(name = "time")
+    @JsonProperty("time")
     private Long time;
 
-    @JSONField(name = "self_id")
+    @JsonProperty("self_id")
     private Long selfId;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/message/GroupMessageEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/message/GroupMessageEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.message;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mikuac.shiro.dto.action.common.Anonymous;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -21,31 +21,31 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode(callSuper = true)
 public class GroupMessageEvent extends MessageEvent {
 
-    @JSONField(name = "message_id")
+    @JsonProperty("message_id")
     private Integer messageId;
 
-    @JSONField(name = "sub_type")
+    @JsonProperty("sub_type")
     private String subType;
 
-    @JSONField(name = "avatar")
+    @JsonProperty("avatar")
     private String avatar;
 
-    @JSONField(name = "real_message_type")
+    @JsonProperty("real_message_type")
     private String realMessageType;
 
-    @JSONField(name = "is_binded_group_id")
+    @JsonProperty("is_binded_group_id")
     private Boolean isBindedGroupId;
 
-    @JSONField(name = "group_id")
+    @JsonProperty("group_id")
     private Long groupId;
 
-    @JSONField(name = "anonymous")
+    @JsonProperty("anonymous")
     private Anonymous anonymous;
 
-    @JSONField(name = "sender")
+    @JsonProperty("sender")
     private GroupSender sender;
 
-    @JSONField(name = "is_binded_user_id")
+    @JsonProperty("is_binded_user_id")
     private Boolean isBindedUserId;
 
     /**
@@ -54,31 +54,31 @@ public class GroupMessageEvent extends MessageEvent {
     @Data
     public static class GroupSender {
 
-        @JSONField(name = "user_id")
+        @JsonProperty("user_id")
         private Long userId;
 
-        @JSONField(name = "nickname")
+        @JsonProperty("nickname")
         private String nickname;
 
-        @JSONField(name = "card")
+        @JsonProperty("card")
         private String card;
 
-        @JSONField(name = "sex")
+        @JsonProperty("sex")
         private String sex;
 
-        @JSONField(name = "age")
+        @JsonProperty("age")
         private Integer age;
 
-        @JSONField(name = "area")
+        @JsonProperty("area")
         private String area;
 
-        @JSONField(name = "level")
+        @JsonProperty("level")
         private String level;
 
-        @JSONField(name = "role")
+        @JsonProperty("role")
         private String role;
 
-        @JSONField(name = "title")
+        @JsonProperty("title")
         private String title;
 
     }

--- a/src/main/java/com/mikuac/shiro/dto/event/message/GuildMessageEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/message/GuildMessageEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.message;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -20,28 +20,28 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode(callSuper = true)
 public class GuildMessageEvent extends MessageEvent {
 
-    @JSONField(name = "message_id")
+    @JsonProperty("message_id")
     private String messageId;
 
-    @JSONField(name = "post_type")
+    @JsonProperty("post_type")
     private String postType;
 
-    @JSONField(name = "sub_type")
+    @JsonProperty("sub_type")
     private String subType;
 
-    @JSONField(name = "guild_id")
+    @JsonProperty("guild_id")
     private String guildId;
 
-    @JSONField(name = "channel_id")
+    @JsonProperty("channel_id")
     private String channelId;
 
-    @JSONField(name = "self_tiny_id")
+    @JsonProperty("self_tiny_id")
     private String selfTinyId;
 
-    @JSONField(name = "time")
+    @JsonProperty("time")
     private Long time;
 
-    @JSONField(name = "sender")
+    @JsonProperty("sender")
     private Sender sender;
 
     /**
@@ -50,13 +50,13 @@ public class GuildMessageEvent extends MessageEvent {
     @Data
     public static class Sender {
 
-        @JSONField(name = "user_id")
+        @JsonProperty("user_id")
         private Long userId;
 
-        @JSONField(name = "tiny_id")
+        @JsonProperty("tiny_id")
         private String tinyId;
 
-        @JSONField(name = "nickname")
+        @JsonProperty("nickname")
         private String nickname;
 
     }

--- a/src/main/java/com/mikuac/shiro/dto/event/message/MessageEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/message/MessageEvent.java
@@ -89,8 +89,8 @@ public class MessageEvent extends Event {
      */
     @Data
     public static class Raw {
-        private Long    msgId;
-        private Long    msgRandom;
+        private Long msgId;
+        private Long msgRandom;
         private Integer msgSeq;
         private Integer chatType;
         private Integer msgType;

--- a/src/main/java/com/mikuac/shiro/dto/event/message/MessageEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/message/MessageEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.message;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mikuac.shiro.dto.event.Event;
 import com.mikuac.shiro.model.ArrayMsg;
 import lombok.AllArgsConstructor;
@@ -24,24 +24,24 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 public class MessageEvent extends Event {
 
-    @JSONField(name = "message_type")
+    @JsonProperty("message_type")
     private String messageType;
 
-    @JSONField(name = "user_id")
+    @JsonProperty("user_id")
     private Long userId;
 
-    @JSONField(name = "message")
+    @JsonProperty("message")
     private String message;
 
-    @JSONField(name = "raw_message")
+    @JsonProperty("raw_message")
     private String rawMessage;
 
-    @JSONField(name = "font")
+    @JsonProperty("font")
     private Integer font;
 
     private List<ArrayMsg> arrayMsg;
 
-    @JSONField(name = "raw")
+    @JsonProperty("raw")
     private Raw raw;
 
     /**

--- a/src/main/java/com/mikuac/shiro/dto/event/message/MessageEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/message/MessageEvent.java
@@ -1,6 +1,12 @@
 package com.mikuac.shiro.dto.event.message;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.mikuac.shiro.common.utils.JsonUtils;
+import com.mikuac.shiro.common.utils.MessageConverser;
 import com.mikuac.shiro.dto.event.Event;
 import com.mikuac.shiro.model.ArrayMsg;
 import lombok.AllArgsConstructor;
@@ -8,6 +14,8 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 
@@ -30,7 +38,7 @@ public class MessageEvent extends Event {
     @JsonProperty("user_id")
     private Long userId;
 
-    @JsonProperty("message")
+    @JsonIgnore
     private String message;
 
     @JsonProperty("raw_message")
@@ -39,10 +47,38 @@ public class MessageEvent extends Event {
     @JsonProperty("font")
     private Integer font;
 
+    @JsonIgnore
     private List<ArrayMsg> arrayMsg;
 
     @JsonProperty("raw")
     private Raw raw;
+
+    @JsonSetter("message")
+    private void setMessageFromJson(JsonNode json) {
+        if (json.isTextual()) {
+            this.message = json.asText();
+            this.arrayMsg = MessageConverser.stringToArray(message);
+        } else if (json.isArray()) {
+            this.arrayMsg = JsonUtils.parseArray(json, ArrayMsg.class);
+            message = MessageConverser.arraysToString(this.arrayMsg);
+        } else {
+            throw new IllegalArgumentException("Invalid message format: " + json);
+        }
+    }
+
+    @JsonIgnore
+    public void setMessage(String message) {
+        this.message = message;
+        this.arrayMsg = MessageConverser.stringToArray(message);
+    }
+
+    @JsonGetter("message")
+    public String getMessage() {
+        if (!StringUtils.hasText(message) && !CollectionUtils.isEmpty(arrayMsg)) {
+            message = MessageConverser.arraysToString(arrayMsg);
+        }
+        return message;
+    }
 
     /**
      * Raw字段在napcat开启debug模式时会出现，其中有msgSeq字段。
@@ -53,8 +89,8 @@ public class MessageEvent extends Event {
      */
     @Data
     public static class Raw {
-        private Long msgId;
-        private Long msgRandom;
+        private Long    msgId;
+        private Long    msgRandom;
         private Integer msgSeq;
         private Integer chatType;
         private Integer msgType;

--- a/src/main/java/com/mikuac/shiro/dto/event/message/PrivateMessageEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/message/PrivateMessageEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.message;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -23,25 +23,25 @@ public class PrivateMessageEvent extends MessageEvent {
     /**
      * 消息 ID
      */
-    @JSONField(name = "message_id")
+    @JsonProperty("message_id")
     private Integer messageId;
 
     /**
      * 消息子类型, 如果是好友则是 friend, 如果是群临时会话则是 group, 如果是在群中自身发送则是 group_self
      */
-    @JSONField(name = "sub_type")
+    @JsonProperty("sub_type")
     private String subType;
 
     /**
      * 发送人信息
      */
-    @JSONField(name = "sender")
+    @JsonProperty("sender")
     private PrivateSender privateSender;
 
     /**
      * 临时会话来源
      */
-    @JSONField(name = "temp_source")
+    @JsonProperty("temp_source")
     private Integer tempSource;
 
     /**
@@ -53,19 +53,19 @@ public class PrivateMessageEvent extends MessageEvent {
         /**
          * 当 subType 值为 group 时，表示本次私聊事件为临时会话，此时 groupId 为来源 QQ 群
          */
-        @JSONField(name = "group_id")
+        @JsonProperty("group_id")
         private Long groupId;
 
-        @JSONField(name = "user_id")
+        @JsonProperty("user_id")
         private Long userId;
 
-        @JSONField(name = "nickname")
+        @JsonProperty("nickname")
         private String nickname;
 
-        @JSONField(name = "sex")
+        @JsonProperty("sex")
         private String sex;
 
-        @JSONField(name = "age")
+        @JsonProperty("age")
         private Integer age;
 
     }

--- a/src/main/java/com/mikuac/shiro/dto/event/meta/HeartbeatMetaEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/meta/HeartbeatMetaEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.meta;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -14,30 +14,30 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode(callSuper = true)
 public class HeartbeatMetaEvent extends MetaEvent {
 
-    @JSONField(name = "time")
+    @JsonProperty("time")
     private Long interval;
 
-    @JSONField(name = "status")
+    @JsonProperty("status")
     private Status status;
 
     @Data
     public static class Status {
-        @JSONField(name = "app_initialized")
+        @JsonProperty("app_initialized")
         Boolean appInitialized;
 
-        @JSONField(name = "app_enabled")
+        @JsonProperty("app_enabled")
         Boolean appEnabled;
 
-        @JSONField(name = "app_good")
+        @JsonProperty("app_good")
         Boolean appIsGood;
 
-        @JSONField(name = "plugins_good")
+        @JsonProperty("plugins_good")
         Boolean pluginsIsGood;
 
-        @JSONField(name = "online")
+        @JsonProperty("online")
         Boolean online;
 
-        @JSONField(name = "stat")
+        @JsonProperty("stat")
         StatusStatistics stat;
 
     }
@@ -45,28 +45,28 @@ public class HeartbeatMetaEvent extends MetaEvent {
     @Data
     public static class StatusStatistics {
 
-        @JSONField(name = "packet_received")
+        @JsonProperty("packet_received")
         Long packetReceived;
 
-        @JSONField(name = "packet_sent")
+        @JsonProperty("packet_sent")
         Long packetSent;
 
-        @JSONField(name = "packet_lost")
+        @JsonProperty("packet_lost")
         Long packetLost;
 
-        @JSONField(name = "message_received")
+        @JsonProperty("message_received")
         Long messageReceived;
 
-        @JSONField(name = "message_sent")
+        @JsonProperty("message_sent")
         Long messageSent;
 
-        @JSONField(name = "disconnect_times")
+        @JsonProperty("disconnect_times")
         Long disconnectTimes;
 
-        @JSONField(name = "lost_times")
+        @JsonProperty("lost_times")
         Long lostTimes;
 
-        @JSONField(name = "last_message_time")
+        @JsonProperty("last_message_time")
         Long lastMessageTime;
 
     }

--- a/src/main/java/com/mikuac/shiro/dto/event/meta/LifecycleMetaEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/meta/LifecycleMetaEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.meta;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -17,6 +17,6 @@ public class LifecycleMetaEvent extends MetaEvent {
     /***
      * just is `enable`, `disable`, `connect`
      */
-    @JSONField(name = "sub_type")
+    @JsonProperty("sub_type")
     private String subType;
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/meta/MetaEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/meta/MetaEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.meta;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mikuac.shiro.dto.event.Event;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -15,10 +15,10 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode(callSuper = true)
 public class MetaEvent extends Event {
 
-    @JSONField(name = "time")
+    @JsonProperty("time")
     private Long time;
 
-    @JSONField(name = "self_id")
+    @JsonProperty("self_id")
     private Long selfId;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/notice/ChannelCreatedNoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/notice/ChannelCreatedNoticeEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.notice;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mikuac.shiro.dto.action.response.ChannelInfoResp;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -24,25 +24,25 @@ public class ChannelCreatedNoticeEvent extends NoticeEvent {
     /**
      * 频道ID
      */
-    @JSONField(name = "guild_id")
+    @JsonProperty("guild_id")
     private String guildId;
 
     /**
      * 子频道ID
      */
-    @JSONField(name = "channel_id")
+    @JsonProperty("channel_id")
     private String channelId;
 
     /**
      * 操作者ID
      */
-    @JSONField(name = "operator_id")
+    @JsonProperty("operator_id")
     private String operatorId;
 
     /**
      * 频道信息
      */
-    @JSONField(name = "channel_info")
+    @JsonProperty("channel_info")
     private ChannelInfoResp channelInfo;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/notice/ChannelDestroyedNoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/notice/ChannelDestroyedNoticeEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.notice;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mikuac.shiro.dto.action.response.ChannelInfoResp;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -24,25 +24,25 @@ public class ChannelDestroyedNoticeEvent extends NoticeEvent {
     /**
      * 频道ID
      */
-    @JSONField(name = "guild_id")
+    @JsonProperty("guild_id")
     private String guildId;
 
     /**
      * 子频道ID
      */
-    @JSONField(name = "channel_id")
+    @JsonProperty("channel_id")
     private String channelId;
 
     /**
      * 操作者ID
      */
-    @JSONField(name = "operator_id")
+    @JsonProperty("operator_id")
     private String operatorId;
 
     /**
      * 频道信息
      */
-    @JSONField(name = "channel_info")
+    @JsonProperty("channel_info")
     private ChannelInfoResp channelInfo;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/notice/ChannelUpdatedNoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/notice/ChannelUpdatedNoticeEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.notice;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mikuac.shiro.dto.action.response.ChannelInfoResp;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -24,31 +24,31 @@ public class ChannelUpdatedNoticeEvent extends NoticeEvent {
     /**
      * 频道ID
      */
-    @JSONField(name = "guild_id")
+    @JsonProperty("guild_id")
     private String guildId;
 
     /**
      * 子频道ID
      */
-    @JSONField(name = "channel_id")
+    @JsonProperty("channel_id")
     private String channelId;
 
     /**
      * 操作者ID
      */
-    @JSONField(name = "operator_id")
+    @JsonProperty("operator_id")
     private String operatorId;
 
     /**
      * 更新前的频道信息
      */
-    @JSONField(name = "old_info")
+    @JsonProperty("old_info")
     private ChannelInfoResp oldInfo;
 
     /**
      * 更新后的频道信息
      */
-    @JSONField(name = "new_info")
+    @JsonProperty("new_info")
     private ChannelInfoResp newInfo;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/notice/FriendAddNoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/notice/FriendAddNoticeEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.notice;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -20,7 +20,7 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode(callSuper = true)
 public class FriendAddNoticeEvent extends NoticeEvent {
 
-    @JSONField(name = "user_id")
+    @JsonProperty("user_id")
     private Long userId;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/notice/GroupAdminNoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/notice/GroupAdminNoticeEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.notice;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -24,19 +24,19 @@ public class GroupAdminNoticeEvent extends NoticeEvent {
      * set、unset
      * 事件子类型, 分别表示设置和取消管理
      */
-    @JSONField(name = "sub_type")
+    @JsonProperty("sub_type")
     private String subType;
 
     /**
      * 群号
      */
-    @JSONField(name = "group_id")
+    @JsonProperty("group_id")
     private Long groupId;
 
     /**
      * 管理员 QQ 号
      */
-    @JSONField(name = "user_id")
+    @JsonProperty("user_id")
     private Long userId;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/notice/GroupBanNoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/notice/GroupBanNoticeEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.notice;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -20,19 +20,19 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode(callSuper = true)
 public class GroupBanNoticeEvent extends NoticeEvent {
 
-    @JSONField(name = "sub_type")
+    @JsonProperty("sub_type")
     private String subType;
 
-    @JSONField(name = "group_id")
+    @JsonProperty("group_id")
     private Long groupId;
 
-    @JSONField(name = "operator_id")
+    @JsonProperty("operator_id")
     private Long operatorId;
 
-    @JSONField(name = "duration")
+    @JsonProperty("duration")
     private Long duration;
 
-    @JSONField(name = "user_id")
+    @JsonProperty("user_id")
     private Long userId;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/notice/GroupCardChangeNoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/notice/GroupCardChangeNoticeEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.notice;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -20,16 +20,16 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode(callSuper = true)
 public class GroupCardChangeNoticeEvent extends NoticeEvent {
 
-    @JSONField(name = "card_new")
+    @JsonProperty("card_new")
     private String cardNew;
 
-    @JSONField(name = "group_id")
+    @JsonProperty("group_id")
     private Long groupId;
 
-    @JSONField(name = "card_old")
+    @JsonProperty("card_old")
     private String cardOld;
 
-    @JSONField(name = "user_id")
+    @JsonProperty("user_id")
     private Long userId;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/notice/GroupDecreaseNoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/notice/GroupDecreaseNoticeEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.notice;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -20,16 +20,16 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode(callSuper = true)
 public class GroupDecreaseNoticeEvent extends NoticeEvent {
 
-    @JSONField(name = "sub_type")
+    @JsonProperty("sub_type")
     private String subType;
 
-    @JSONField(name = "group_id")
+    @JsonProperty("group_id")
     private Long groupId;
 
-    @JSONField(name = "operator_id")
+    @JsonProperty("operator_id")
     private Long operatorId;
 
-    @JSONField(name = "user_id")
+    @JsonProperty("user_id")
     private Long userId;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/notice/GroupHonorChangeNoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/notice/GroupHonorChangeNoticeEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.notice;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -20,16 +20,16 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode(callSuper = true)
 public class GroupHonorChangeNoticeEvent extends NoticeEvent {
 
-    @JSONField(name = "sub_type")
+    @JsonProperty("sub_type")
     private String subType;
 
-    @JSONField(name = "group_id")
+    @JsonProperty("group_id")
     private Long groupId;
 
-    @JSONField(name = "honor_type")
+    @JsonProperty("honor_type")
     private String honorType;
 
-    @JSONField(name = "user_id")
+    @JsonProperty("user_id")
     private Long userId;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/notice/GroupIncreaseNoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/notice/GroupIncreaseNoticeEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.notice;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -20,16 +20,16 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode(callSuper = true)
 public class GroupIncreaseNoticeEvent extends NoticeEvent {
 
-    @JSONField(name = "sub_type")
+    @JsonProperty("sub_type")
     private String subType;
 
-    @JSONField(name = "group_id")
+    @JsonProperty("group_id")
     private Long groupId;
 
-    @JSONField(name = "operator_id")
+    @JsonProperty("operator_id")
     private Long operatorId;
 
-    @JSONField(name = "user_id")
+    @JsonProperty("user_id")
     private Long userId;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/notice/GroupLuckyKingNoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/notice/GroupLuckyKingNoticeEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.notice;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -20,16 +20,16 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode(callSuper = true)
 public class GroupLuckyKingNoticeEvent extends NoticeEvent {
 
-    @JSONField(name = "sub_type")
+    @JsonProperty("sub_type")
     private String subType;
 
-    @JSONField(name = "group_id")
+    @JsonProperty("group_id")
     private Long groupId;
 
-    @JSONField(name = "target_id")
+    @JsonProperty("target_id")
     private Long targetId;
 
-    @JSONField(name = "user_id")
+    @JsonProperty("user_id")
     private Long userId;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/notice/GroupMessageReactionNoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/notice/GroupMessageReactionNoticeEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.notice;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -20,19 +20,19 @@ public class GroupMessageReactionNoticeEvent extends NoticeEvent {
     /**
      * 群组ID
      */
-    @JSONField(name = "group_id")
+    @JsonProperty("group_id")
     private Long groupId;
 
     /**
      * 消息ID
      */
-    @JSONField(name = "message_id")
+    @JsonProperty("message_id")
     private Integer messageId;
 
     /**
      * 操作者ID
      */
-    @JSONField(name = "operator_id")
+    @JsonProperty("operator_id")
     private Long operatorId;
 
     /**
@@ -40,19 +40,19 @@ public class GroupMessageReactionNoticeEvent extends NoticeEvent {
      * remove
      * add
      */
-    @JSONField(name = "sub_type")
+    @JsonProperty("sub_type")
     private String subType;
 
     /**
      * 操作者ID
      */
-    @JSONField(name = "code")
+    @JsonProperty("code")
     private String code;
 
     /**
      * 操作者ID
      */
-    @JSONField(name = "count")
+    @JsonProperty("count")
     private Integer count;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/notice/GroupMsgDeleteNoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/notice/GroupMsgDeleteNoticeEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.notice;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -20,16 +20,16 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode(callSuper = true)
 public class GroupMsgDeleteNoticeEvent extends NoticeEvent {
 
-    @JSONField(name = "group_id")
+    @JsonProperty("group_id")
     private Long groupId;
 
-    @JSONField(name = "user_id")
+    @JsonProperty("user_id")
     private Long userId;
 
-    @JSONField(name = "operator_id")
+    @JsonProperty("operator_id")
     private Long operatorId;
 
-    @JSONField(name = "message_id")
+    @JsonProperty("message_id")
     private Integer messageId;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/notice/GroupUploadNoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/notice/GroupUploadNoticeEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.notice;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -20,10 +20,10 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode(callSuper = true)
 public class GroupUploadNoticeEvent extends NoticeEvent {
 
-    @JSONField(name = "group_id")
+    @JsonProperty("group_id")
     private Long groupId;
 
-    @JSONField(name = "file")
+    @JsonProperty("file")
     private File file;
 
     /**
@@ -32,19 +32,19 @@ public class GroupUploadNoticeEvent extends NoticeEvent {
     @Data
     public static class File {
 
-        @JSONField(name = "id")
+        @JsonProperty("id")
         private String id;
 
-        @JSONField(name = "name")
+        @JsonProperty("name")
         private String name;
 
-        @JSONField(name = "size")
+        @JsonProperty("size")
         private Long size;
 
-        @JSONField(name = "busid")
+        @JsonProperty("busid")
         private Long busid;
 
-        @JSONField(name = "url")
+        @JsonProperty("url")
         private String url;
 
     }

--- a/src/main/java/com/mikuac/shiro/dto/event/notice/MessageReactionsUpdatedNoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/notice/MessageReactionsUpdatedNoticeEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.notice;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -25,19 +25,19 @@ public class MessageReactionsUpdatedNoticeEvent extends NoticeEvent {
     /**
      * 频道ID
      */
-    @JSONField(name = "guild_id")
+    @JsonProperty("guild_id")
     private String guildId;
 
     /**
      * 子频道ID
      */
-    @JSONField(name = "channel_id")
+    @JsonProperty("channel_id")
     private String channelId;
 
     /**
      * 消息ID
      */
-    @JSONField(name = "message_id")
+    @JsonProperty("message_id")
     private String messageId;
 
     /**
@@ -51,37 +51,37 @@ public class MessageReactionsUpdatedNoticeEvent extends NoticeEvent {
         /**
          * 表情ID
          */
-        @JSONField(name = "emoji_id")
+        @JsonProperty("emoji_id")
         private String emojiId;
 
         /**
          * 表情对应数值ID
          */
-        @JSONField(name = "emoji_index")
+        @JsonProperty("emoji_index")
         private Integer emojiIndex;
 
         /**
          * 表情类型
          */
-        @JSONField(name = "emoji_type")
+        @JsonProperty("emoji_type")
         private Integer emojiType;
 
         /**
          * 表情名字
          */
-        @JSONField(name = "emoji_name")
+        @JsonProperty("emoji_name")
         private String emojiName;
 
         /**
          * 当前表情被贴数量
          */
-        @JSONField(name = "count")
+        @JsonProperty("count")
         private Integer count;
 
         /**
          * BOT是否点击
          */
-        @JSONField(name = "clicked")
+        @JsonProperty("clicked")
         private Boolean clicked;
 
     }

--- a/src/main/java/com/mikuac/shiro/dto/event/notice/NoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/notice/NoticeEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.notice;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mikuac.shiro.dto.event.Event;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -21,10 +21,10 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode(callSuper = true)
 public class NoticeEvent extends Event {
 
-    @JSONField(name = "notice_type")
+    @JsonProperty("notice_type")
     private String noticeType;
 
-    @JSONField(name = "user_id")
+    @JsonProperty("user_id")
     private Long userId;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/notice/PokeNoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/notice/PokeNoticeEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.notice;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -20,25 +20,25 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode(callSuper = true)
 public class PokeNoticeEvent extends NoticeEvent {
 
-    @JSONField(name = "sub_type")
+    @JsonProperty("sub_type")
     private String subType;
 
-    @JSONField(name = "self_id")
+    @JsonProperty("self_id")
     private Long selfId;
 
-    @JSONField(name = "sender_id")
+    @JsonProperty("sender_id")
     private Long senderId;
 
-    @JSONField(name = "user_id")
+    @JsonProperty("user_id")
     private Long userId;
 
-    @JSONField(name = "target_id")
+    @JsonProperty("target_id")
     private Long targetId;
 
-    @JSONField(name = "group_id")
+    @JsonProperty("group_id")
     private Long groupId;
 
-    @JSONField(name = "time")
+    @JsonProperty("time")
     private Long time;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/notice/PrivateMsgDeleteNoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/notice/PrivateMsgDeleteNoticeEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.notice;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -20,10 +20,10 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode(callSuper = true)
 public class PrivateMsgDeleteNoticeEvent extends NoticeEvent {
 
-    @JSONField(name = "user_id")
+    @JsonProperty("user_id")
     private Long userId;
 
-    @JSONField(name = "message_id")
+    @JsonProperty("message_id")
     private Integer messageId;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/notice/ReceiveOfflineFilesNoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/notice/ReceiveOfflineFilesNoticeEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.notice;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -20,10 +20,10 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode(callSuper = true)
 public class ReceiveOfflineFilesNoticeEvent extends NoticeEvent {
 
-    @JSONField(name = "user_id")
+    @JsonProperty("user_id")
     private Long userId;
 
-    @JSONField(name = "file")
+    @JsonProperty("file")
     private File file;
 
     /**
@@ -32,13 +32,13 @@ public class ReceiveOfflineFilesNoticeEvent extends NoticeEvent {
     @Data
     public static class File {
 
-        @JSONField(name = "name")
+        @JsonProperty("name")
         private String name;
 
-        @JSONField(name = "size")
+        @JsonProperty("size")
         private Long size;
 
-        @JSONField(name = "url")
+        @JsonProperty("url")
         private String url;
 
     }

--- a/src/main/java/com/mikuac/shiro/dto/event/request/GroupAddRequestEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/request/GroupAddRequestEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.request;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -20,13 +20,13 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode(callSuper = true)
 public class GroupAddRequestEvent extends RequestEvent {
 
-    @JSONField(name = "sub_type")
+    @JsonProperty("sub_type")
     private String subType;
 
-    @JSONField(name = "group_id")
+    @JsonProperty("group_id")
     private Long groupId;
 
-    @JSONField(name = "invitor_id")
+    @JsonProperty("invitor_id")
     private Long invitorId;
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/request/RequestEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/request/RequestEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.dto.event.request;
 
-import com.alibaba.fastjson2.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mikuac.shiro.dto.event.Event;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -21,16 +21,16 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode(callSuper = true)
 public class RequestEvent extends Event {
 
-    @JSONField(name = "request_type")
+    @JsonProperty("request_type")
     private String requestType;
 
-    @JSONField(name = "user_id")
+    @JsonProperty("user_id")
     private Long userId;
 
-    @JSONField(name = "comment")
+    @JsonProperty("comment")
     private String comment;
 
-    @JSONField(name = "flag")
+    @JsonProperty("flag")
     private String flag;
 
 }

--- a/src/main/java/com/mikuac/shiro/handler/ActionHandler.java
+++ b/src/main/java/com/mikuac/shiro/handler/ActionHandler.java
@@ -1,9 +1,9 @@
 package com.mikuac.shiro.handler;
 
-import com.alibaba.fastjson2.JSON;
-import com.alibaba.fastjson2.JSONObject;
 import com.mikuac.shiro.common.limit.RateLimiter;
 import com.mikuac.shiro.common.utils.ConnectionUtils;
+import com.mikuac.shiro.common.utils.JsonObjectWrapper;
+import com.mikuac.shiro.common.utils.JsonUtils;
 import com.mikuac.shiro.common.utils.PayloadSender;
 import com.mikuac.shiro.constant.ActionParams;
 import com.mikuac.shiro.enums.ActionPath;
@@ -72,7 +72,7 @@ public class ActionHandler {
      *
      * @param resp 回调结果
      */
-    public void onReceiveActionResp(JSONObject resp) {
+    public void onReceiveActionResp(JsonObjectWrapper resp) {
         String e = resp.get("echo").toString();
         PayloadSender sender = callback.get(e);
         if (sender != null) {
@@ -90,7 +90,7 @@ public class ActionHandler {
      * @param params  请求参数
      * @return 请求结果
      */
-    public JSONObject action(WebSocketSession session, ActionPath action, Map<String, Object> params) {
+    public JsonObjectWrapper action(WebSocketSession session, ActionPath action, Map<String, Object> params) {
         return act(session, action, keyboardSerialize(params));
     }
 
@@ -102,12 +102,12 @@ public class ActionHandler {
      * @param params  请求参数
      * @return 请求结果
      */
-    public JSONObject rawAction(WebSocketSession session, ActionPath action, Map<String, Object> params) {
+    public JsonObjectWrapper rawAction(WebSocketSession session, ActionPath action, Map<String, Object> params) {
         return act(session, action, params);
     }
 
-    private JSONObject act(WebSocketSession session, ActionPath action, Map<String, Object> params) {
-        JSONObject result = new JSONObject();
+    private JsonObjectWrapper act(WebSocketSession session, ActionPath action, Map<String, Object> params) {
+        JsonObjectWrapper result = new JsonObjectWrapper();
         if (Boolean.TRUE.equals(rateLimiterProps.getEnable())) {
             if (Boolean.TRUE.equals(rateLimiterProps.getAwaitTask()) && !rateLimiter.acquire()) {
                 // 阻塞当前线程直到获取令牌成功
@@ -129,7 +129,7 @@ public class ActionHandler {
             }
         }
 
-        JSONObject payload = generatePayload(action, params);
+        JsonObjectWrapper payload = generatePayload(action, params);
         PayloadSender sender = new PayloadSender(session, wsProp.getTimeout());
         callback.put(payload.get("echo").toString(), sender);
         try {
@@ -152,8 +152,8 @@ public class ActionHandler {
      * @param params 请求参数
      * @return 请求数据结构
      */
-    private JSONObject generatePayload(ActionPath action, Map<String, Object> params) {
-        JSONObject payload = new JSONObject();
+    private JsonObjectWrapper generatePayload(ActionPath action, Map<String, Object> params) {
+        JsonObjectWrapper payload = new JsonObjectWrapper();
         payload.put("action", action.getPath());
         payload.put("echo", echo.getAndIncrement());
         if (params != null && !params.isEmpty()) {
@@ -175,7 +175,7 @@ public class ActionHandler {
         List<Object> modified = original.stream().map(v -> {
             if (v instanceof ArrayMsg arrayMsg && arrayMsg.getType() == MsgTypeEnum.keyboard) {
                 String data = arrayMsg.getData().get("keyboard");
-                return JSON.parseObject(data);
+                return JsonUtils.parseObject(data);
             }
             return v;
         }).toList();

--- a/src/main/java/com/mikuac/shiro/handler/ActionHandler.java
+++ b/src/main/java/com/mikuac/shiro/handler/ActionHandler.java
@@ -174,7 +174,7 @@ public class ActionHandler {
 
         List<Object> modified = original.stream().map(v -> {
             if (v instanceof ArrayMsg arrayMsg && arrayMsg.getType() == MsgTypeEnum.keyboard) {
-                String data = arrayMsg.getData().get("keyboard");
+                String data = arrayMsg.getStringData("keyboard");
                 return JsonUtils.parseObject(data);
             }
             return v;

--- a/src/main/java/com/mikuac/shiro/handler/EventHandler.java
+++ b/src/main/java/com/mikuac/shiro/handler/EventHandler.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.handler;
 
-import com.alibaba.fastjson2.JSONObject;
+import com.mikuac.shiro.common.utils.JsonObjectWrapper;
 import com.mikuac.shiro.core.Bot;
 import com.mikuac.shiro.handler.event.*;
 import lombok.extern.slf4j.Slf4j;
@@ -43,7 +43,7 @@ public class EventHandler implements ApplicationRunner {
     /**
      * 存储事件处理器
      */
-    private final Map<String, BiConsumer<Bot, JSONObject>> handlers = new HashMap<>();
+    private final Map<String, BiConsumer<Bot, JsonObjectWrapper>> handlers = new HashMap<>();
 
     @Override
     public void run(ApplicationArguments args) {
@@ -96,9 +96,9 @@ public class EventHandler implements ApplicationRunner {
      * 事件分发
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void handler(Bot bot, JSONObject resp) {
+    public void handler(Bot bot, JsonObjectWrapper resp) {
         String postType = resp.getString("post_type");
         handlers.getOrDefault(postType, (b, e) -> {
         }).accept(bot, resp);

--- a/src/main/java/com/mikuac/shiro/handler/event/MessageEvent.java
+++ b/src/main/java/com/mikuac/shiro/handler/event/MessageEvent.java
@@ -75,7 +75,7 @@ public class MessageEvent {
                 if (utils.setInterceptor(bot, event)) {
                     return;
                 }
-                MessageConverser.convert(event.getMessage(), event);
+
                 resp.put("message", event.getMessage());
                 utils.pushAnyMessageEvent(bot, resp, event.getArrayMsg());
                 injection.invokePrivateMessage(bot, event);
@@ -98,7 +98,7 @@ public class MessageEvent {
                 if (utils.setInterceptor(bot, event)) {
                     return;
                 }
-                MessageConverser.convert(event.getMessage(), event);
+
                 resp.put("message", event.getMessage());
                 utils.pushAnyMessageEvent(bot, resp, event.getArrayMsg());
                 injection.invokeGroupMessage(bot, event);
@@ -111,7 +111,7 @@ public class MessageEvent {
                 if (utils.setInterceptor(bot, event)) {
                     return;
                 }
-                MessageConverser.convert(event.getMessage(), event);
+
                 injection.invokeGuildMessage(bot, event);
                 bot.getPluginList().stream().anyMatch(o -> utils.getPlugin(o).onGuildMessage(bot, event) == BotPlugin.MESSAGE_BLOCK);
                 utils.getInterceptor(bot.getBotMessageEventInterceptor()).afterCompletion(bot, event);

--- a/src/main/java/com/mikuac/shiro/handler/event/MessageEvent.java
+++ b/src/main/java/com/mikuac/shiro/handler/event/MessageEvent.java
@@ -3,7 +3,6 @@ package com.mikuac.shiro.handler.event;
 import com.mikuac.shiro.common.utils.EventUtils;
 import com.mikuac.shiro.common.utils.GroupMessageFilterUtils;
 import com.mikuac.shiro.common.utils.JsonObjectWrapper;
-import com.mikuac.shiro.common.utils.MessageConverser;
 import com.mikuac.shiro.core.Bot;
 import com.mikuac.shiro.core.BotContainer;
 import com.mikuac.shiro.core.BotPlugin;
@@ -75,7 +74,6 @@ public class MessageEvent {
                 if (utils.setInterceptor(bot, event)) {
                     return;
                 }
-
                 resp.put("message", event.getMessage());
                 utils.pushAnyMessageEvent(bot, resp, event.getArrayMsg());
                 injection.invokePrivateMessage(bot, event);
@@ -98,7 +96,6 @@ public class MessageEvent {
                 if (utils.setInterceptor(bot, event)) {
                     return;
                 }
-
                 resp.put("message", event.getMessage());
                 utils.pushAnyMessageEvent(bot, resp, event.getArrayMsg());
                 injection.invokeGroupMessage(bot, event);
@@ -111,7 +108,6 @@ public class MessageEvent {
                 if (utils.setInterceptor(bot, event)) {
                     return;
                 }
-
                 injection.invokeGuildMessage(bot, event);
                 bot.getPluginList().stream().anyMatch(o -> utils.getPlugin(o).onGuildMessage(bot, event) == BotPlugin.MESSAGE_BLOCK);
                 utils.getInterceptor(bot.getBotMessageEventInterceptor()).afterCompletion(bot, event);

--- a/src/main/java/com/mikuac/shiro/handler/event/MessageEvent.java
+++ b/src/main/java/com/mikuac/shiro/handler/event/MessageEvent.java
@@ -1,8 +1,8 @@
 package com.mikuac.shiro.handler.event;
 
-import com.alibaba.fastjson2.JSONObject;
 import com.mikuac.shiro.common.utils.EventUtils;
 import com.mikuac.shiro.common.utils.GroupMessageFilterUtils;
+import com.mikuac.shiro.common.utils.JsonObjectWrapper;
 import com.mikuac.shiro.common.utils.MessageConverser;
 import com.mikuac.shiro.core.Bot;
 import com.mikuac.shiro.core.BotContainer;
@@ -46,15 +46,15 @@ public class MessageEvent {
     /**
      * 存储消息事件处理器
      */
-    public final Map<String, BiConsumer<Bot, JSONObject>> handlers = new HashMap<>();
+    public final Map<String, BiConsumer<Bot, JsonObjectWrapper>> handlers = new HashMap<>();
 
     /**
      * 消息事件分发
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void handler(Bot bot, JSONObject resp) {
+    public void handler(Bot bot, JsonObjectWrapper resp) {
         String type = resp.getString("message_type");
         handlers.getOrDefault(type, (b, e) -> {
         }).accept(bot, resp);
@@ -64,11 +64,11 @@ public class MessageEvent {
      * 事件处理
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      * @param type {@link MessageEventEnum}
      */
     @SuppressWarnings({"ResultOfMethodCallIgnored", "squid:S2201", "squid:S3776"})
-    private void process(Bot bot, JSONObject resp, MessageEventEnum type) {
+    private void process(Bot bot, JsonObjectWrapper resp, MessageEventEnum type) {
         try {
             if (type == MessageEventEnum.FRIEND) {
                 PrivateMessageEvent event = resp.to(PrivateMessageEvent.class);
@@ -125,9 +125,9 @@ public class MessageEvent {
      * 私聊请求
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void friend(Bot bot, JSONObject resp) {
+    public void friend(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, MessageEventEnum.FRIEND);
     }
 
@@ -135,9 +135,9 @@ public class MessageEvent {
      * 群消息
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void group(Bot bot, JSONObject resp) {
+    public void group(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, MessageEventEnum.GROUP);
     }
 
@@ -145,9 +145,9 @@ public class MessageEvent {
      * 频道消息
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void guild(Bot bot, JSONObject resp) {
+    public void guild(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, MessageEventEnum.GUILD);
     }
 

--- a/src/main/java/com/mikuac/shiro/handler/event/MetaEvent.java
+++ b/src/main/java/com/mikuac/shiro/handler/event/MetaEvent.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.handler.event;
 
-import com.alibaba.fastjson2.JSONObject;
+import com.mikuac.shiro.common.utils.JsonObjectWrapper;
 import com.mikuac.shiro.core.Bot;
 import com.mikuac.shiro.dto.event.meta.HeartbeatMetaEvent;
 import com.mikuac.shiro.dto.event.meta.LifecycleMetaEvent;
@@ -31,25 +31,25 @@ public class MetaEvent {
     /**
      * 存储元事件处理器
      */
-    public final Map<String, BiConsumer<Bot, JSONObject>> handlers = new HashMap<>();
+    public final Map<String, BiConsumer<Bot, JsonObjectWrapper>> handlers = new HashMap<>();
 
     /**
      * 元事件分发
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void handler(Bot bot, JSONObject resp) {
+    public void handler(Bot bot, JsonObjectWrapper resp) {
         String type = resp.getString("meta_event_type");
         handlers.getOrDefault(type, (b, e) -> {
         }).accept(bot, resp);
     }
 
-    public void heartbeat(Bot bot, JSONObject resp) {
+    public void heartbeat(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, MetaEventEnum.HEARTBEAT);
     }
 
-    public void lifecycle(Bot bot, JSONObject resp) {
+    public void lifecycle(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, MetaEventEnum.LIFECYCLE);
     }
 
@@ -57,11 +57,11 @@ public class MetaEvent {
      * 事件处理
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      * @param type {@link NotifyEventEnum}
      */
     @SuppressWarnings("unsed")
-    private void process(Bot bot, JSONObject resp, MetaEventEnum type) {
+    private void process(Bot bot, JsonObjectWrapper resp, MetaEventEnum type) {
         switch (type) {
             case HEARTBEAT -> {
                 HeartbeatMetaEvent event = resp.to(HeartbeatMetaEvent.class);

--- a/src/main/java/com/mikuac/shiro/handler/event/NoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/handler/event/NoticeEvent.java
@@ -1,7 +1,7 @@
 package com.mikuac.shiro.handler.event;
 
-import com.alibaba.fastjson2.JSONObject;
 import com.mikuac.shiro.common.utils.EventUtils;
+import com.mikuac.shiro.common.utils.JsonObjectWrapper;
 import com.mikuac.shiro.core.Bot;
 import com.mikuac.shiro.core.BotPlugin;
 import com.mikuac.shiro.dto.event.notice.*;
@@ -34,15 +34,15 @@ public class NoticeEvent {
     /**
      * 存储通知事件处理器
      */
-    public final Map<String, BiConsumer<Bot, JSONObject>> handlers = new HashMap<>();
+    public final Map<String, BiConsumer<Bot, JsonObjectWrapper>> handlers = new HashMap<>();
 
     /**
      * 通知事件分发
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void handler(Bot bot, JSONObject resp) {
+    public void handler(Bot bot, JsonObjectWrapper resp) {
         String type = resp.getString("notice_type");
         handlers.getOrDefault(
                 type,
@@ -55,11 +55,11 @@ public class NoticeEvent {
      * 事件处理
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      * @param type {@link NoticeEventEnum}
      */
     @SuppressWarnings({"ResultOfMethodCallIgnored", "squid:S2201"})
-    private void process(Bot bot, JSONObject resp, NoticeEventEnum type) {
+    private void process(Bot bot, JsonObjectWrapper resp, NoticeEventEnum type) {
         if (type == NoticeEventEnum.GROUP_UPLOAD) {
             GroupUploadNoticeEvent event = resp.to(GroupUploadNoticeEvent.class);
             injection.invokeGroupUploadNotice(bot, event);
@@ -150,9 +150,9 @@ public class NoticeEvent {
      * 群文件上传
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void groupUpload(Bot bot, JSONObject resp) {
+    public void groupUpload(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, NoticeEventEnum.GROUP_UPLOAD);
     }
 
@@ -160,9 +160,9 @@ public class NoticeEvent {
      * 群管理员变动
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void groupAdmin(Bot bot, JSONObject resp) {
+    public void groupAdmin(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, NoticeEventEnum.GROUP_ADMIN);
     }
 
@@ -170,9 +170,9 @@ public class NoticeEvent {
      * 群成员减少
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void groupDecrease(Bot bot, JSONObject resp) {
+    public void groupDecrease(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, NoticeEventEnum.GROUP_DECREASE);
     }
 
@@ -180,9 +180,9 @@ public class NoticeEvent {
      * 群成员增加
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void groupIncrease(Bot bot, JSONObject resp) {
+    public void groupIncrease(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, NoticeEventEnum.GROUP_INCREASE);
     }
 
@@ -190,9 +190,9 @@ public class NoticeEvent {
      * 群禁言
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void groupBan(Bot bot, JSONObject resp) {
+    public void groupBan(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, NoticeEventEnum.GROUP_BAN);
     }
 
@@ -200,9 +200,9 @@ public class NoticeEvent {
      * 好友添加
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void friendAdd(Bot bot, JSONObject resp) {
+    public void friendAdd(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, NoticeEventEnum.FRIEND_ADD);
     }
 
@@ -210,17 +210,17 @@ public class NoticeEvent {
      * 群消息撤回
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void groupMsgDelete(Bot bot, JSONObject resp) {
+    public void groupMsgDelete(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, NoticeEventEnum.GROUP_MSG_DELETE);
     }
 
     /**
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void privateMsgDelete(Bot bot, JSONObject resp) {
+    public void privateMsgDelete(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, NoticeEventEnum.PRIVATE_MSG_DELETE);
     }
 
@@ -228,9 +228,9 @@ public class NoticeEvent {
      * 群成员名片更新
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void groupCardChange(Bot bot, JSONObject resp) {
+    public void groupCardChange(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, NoticeEventEnum.GROUP_CARD_CHANGE);
     }
 
@@ -238,9 +238,9 @@ public class NoticeEvent {
      * 接收到离线文件
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void offlineFile(Bot bot, JSONObject resp) {
+    public void offlineFile(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, NoticeEventEnum.OFFLINE_FILE);
     }
 
@@ -248,9 +248,9 @@ public class NoticeEvent {
      * 子频道创建
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void channelCreated(Bot bot, JSONObject resp) {
+    public void channelCreated(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, NoticeEventEnum.CHANNEL_CREATED);
     }
 
@@ -258,9 +258,9 @@ public class NoticeEvent {
      * 子频道删除
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void channelDestroyed(Bot bot, JSONObject resp) {
+    public void channelDestroyed(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, NoticeEventEnum.CHANNEL_DESTROYED);
     }
 
@@ -268,9 +268,9 @@ public class NoticeEvent {
      * 子频道信息更新
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void channelUpdated(Bot bot, JSONObject resp) {
+    public void channelUpdated(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, NoticeEventEnum.CHANNEL_UPDATED);
     }
 
@@ -278,9 +278,9 @@ public class NoticeEvent {
      * 频道消息表情贴更新
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void messageReactionsUpdated(Bot bot, JSONObject resp) {
+    public void messageReactionsUpdated(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, NoticeEventEnum.MESSAGE_REACTIONS_UPDATED);
     }
 
@@ -288,9 +288,9 @@ public class NoticeEvent {
      * 子通知事件
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void notify(Bot bot, JSONObject resp) {
+    public void notify(Bot bot, JsonObjectWrapper resp) {
         notify.handler(bot, resp);
     }
 
@@ -298,9 +298,9 @@ public class NoticeEvent {
      * 群消息表情贴
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void groupReactionMessage(Bot bot, JSONObject resp) {
+    public void groupReactionMessage(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, NoticeEventEnum.GROUP_MESSAGE_REACTION);
     }
 

--- a/src/main/java/com/mikuac/shiro/handler/event/NotifyEvent.java
+++ b/src/main/java/com/mikuac/shiro/handler/event/NotifyEvent.java
@@ -1,7 +1,7 @@
 package com.mikuac.shiro.handler.event;
 
-import com.alibaba.fastjson2.JSONObject;
 import com.mikuac.shiro.common.utils.EventUtils;
+import com.mikuac.shiro.common.utils.JsonObjectWrapper;
 import com.mikuac.shiro.core.Bot;
 import com.mikuac.shiro.core.BotPlugin;
 import com.mikuac.shiro.dto.event.notice.GroupHonorChangeNoticeEvent;
@@ -34,15 +34,15 @@ public class NotifyEvent {
     /**
      * 存储通知事件处理器
      */
-    public final Map<String, BiConsumer<Bot, JSONObject>> handlers = new HashMap<>();
+    public final Map<String, BiConsumer<Bot, JsonObjectWrapper>> handlers = new HashMap<>();
 
     /**
      * 通知事件分发
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void handler(Bot bot, JSONObject resp) {
+    public void handler(Bot bot, JsonObjectWrapper resp) {
         String type = resp.getString("sub_type");
         handlers.getOrDefault(type, (b, e) -> {
         }).accept(bot, resp);
@@ -52,11 +52,11 @@ public class NotifyEvent {
      * 事件处理
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      * @param type {@link NotifyEventEnum}
      */
     @SuppressWarnings({"ResultOfMethodCallIgnored", "squid:S2201"})
-    private void process(Bot bot, JSONObject resp, NotifyEventEnum type) {
+    private void process(Bot bot, JsonObjectWrapper resp, NotifyEventEnum type) {
         if (type == NotifyEventEnum.POKE) {
             PokeNoticeEvent event = resp.to(PokeNoticeEvent.class);
             // 如果群号不为空则作为群内戳一戳处理
@@ -84,9 +84,9 @@ public class NotifyEvent {
      * 戳一戳事件
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void poke(Bot bot, JSONObject resp) {
+    public void poke(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, NotifyEventEnum.POKE);
     }
 
@@ -94,9 +94,9 @@ public class NotifyEvent {
      * 抢红包运气王事件
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void luckyKing(Bot bot, JSONObject resp) {
+    public void luckyKing(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, NotifyEventEnum.LUCKY_KING);
     }
 
@@ -104,9 +104,9 @@ public class NotifyEvent {
      * 群荣誉变更事件
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void honor(Bot bot, JSONObject resp) {
+    public void honor(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, NotifyEventEnum.HONOR);
     }
 

--- a/src/main/java/com/mikuac/shiro/handler/event/RequestEvent.java
+++ b/src/main/java/com/mikuac/shiro/handler/event/RequestEvent.java
@@ -1,7 +1,7 @@
 package com.mikuac.shiro.handler.event;
 
-import com.alibaba.fastjson2.JSONObject;
 import com.mikuac.shiro.common.utils.EventUtils;
+import com.mikuac.shiro.common.utils.JsonObjectWrapper;
 import com.mikuac.shiro.core.Bot;
 import com.mikuac.shiro.core.BotPlugin;
 import com.mikuac.shiro.dto.event.request.FriendAddRequestEvent;
@@ -33,15 +33,15 @@ public class RequestEvent {
     /**
      * 存储请求事件处理器
      */
-    public final Map<String, BiConsumer<Bot, JSONObject>> handlers = new HashMap<>();
+    public final Map<String, BiConsumer<Bot, JsonObjectWrapper>> handlers = new HashMap<>();
 
     /**
      * 请求事件分发
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void handler(Bot bot, JSONObject resp) {
+    public void handler(Bot bot, JsonObjectWrapper resp) {
         String type = resp.getString("request_type");
         handlers.getOrDefault(
                 type,
@@ -54,11 +54,11 @@ public class RequestEvent {
      * 事件处理
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      * @param type {@link RequestEventEnum}
      */
     @SuppressWarnings({"ResultOfMethodCallIgnored", "squid:S2201"})
-    private void process(Bot bot, JSONObject resp, RequestEventEnum type) {
+    private void process(Bot bot, JsonObjectWrapper resp, RequestEventEnum type) {
         if (type == RequestEventEnum.GROUP) {
             GroupAddRequestEvent event = resp.to(GroupAddRequestEvent.class);
             injection.invokeGroupAddRequest(bot, event);
@@ -75,9 +75,9 @@ public class RequestEvent {
      * 加好友请求
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void friend(Bot bot, JSONObject resp) {
+    public void friend(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, RequestEventEnum.FRIEND);
     }
 
@@ -85,9 +85,9 @@ public class RequestEvent {
      * 加群请求
      *
      * @param bot  {@link Bot}
-     * @param resp {@link JSONObject}
+     * @param resp {@link JsonObjectWrapper}
      */
-    public void group(Bot bot, JSONObject resp) {
+    public void group(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, RequestEventEnum.GROUP);
     }
 

--- a/src/main/java/com/mikuac/shiro/model/ArrayMsg.java
+++ b/src/main/java/com/mikuac/shiro/model/ArrayMsg.java
@@ -68,16 +68,7 @@ public class ArrayMsg {
             data = JsonUtils.getObjectMapper().createObjectNode();
         }
         map.forEach((key, value) -> {
-            JsonNode valueNode;
-            try {
-                if (value instanceof String s) {
-                    valueNode = JsonUtils.getObjectMapper().readTree(s);
-                } else {
-                    valueNode = JsonUtils.getObjectMapper().valueToTree(value);
-                }
-            } catch (Exception e) {
-                valueNode = JsonUtils.getObjectMapper().getNodeFactory().textNode(value.toString());
-            }
+            JsonNode valueNode = JsonUtils.getObjectMapper().valueToTree(value);
             ((ObjectNode) data).set(key, valueNode);
         });
         return this;
@@ -105,18 +96,11 @@ public class ArrayMsg {
     }
 
     public long getLongData(String key) {
-        var value = data.get(key);
-        if (value == null || !value.isLong()) {
-            return 0;
-        }
-        return value.asLong();
+        return data.has(key) ? data.get(key).asLong() : 0;
     }
 
     public String getStringData(String key) {
-        var value = data.get(key);
-        if (value == null) {
-            return "";
-        }
-        return JsonUtils.nodeToString(value);
+        return data.has(key) ? JsonUtils.nodeToString(data.get(key)) : "";
     }
+
 }

--- a/src/main/java/com/mikuac/shiro/model/ArrayMsg.java
+++ b/src/main/java/com/mikuac/shiro/model/ArrayMsg.java
@@ -67,10 +67,7 @@ public class ArrayMsg {
         if (data == null) {
             data = JsonUtils.getObjectMapper().createObjectNode();
         }
-        map.forEach((key, value) -> {
-            JsonNode valueNode = JsonUtils.getObjectMapper().valueToTree(value);
-            ((ObjectNode) data).set(key, valueNode);
-        });
+        map.forEach((key, value) -> ((ObjectNode) data).set(key, JsonUtils.parseToJsonNode(value)));
         return this;
     }
 

--- a/src/main/java/com/mikuac/shiro/model/ArrayMsg.java
+++ b/src/main/java/com/mikuac/shiro/model/ArrayMsg.java
@@ -94,12 +94,11 @@ public class ArrayMsg {
         }
         StringBuilder stringBuilder = new StringBuilder("[CQ:");
         stringBuilder.append(getRawType());
-        data.properties().forEach((e) -> {
-
+        data.properties().forEach(v -> {
             stringBuilder.append(',');
-            stringBuilder.append(e.getKey());
+            stringBuilder.append(v.getKey());
             stringBuilder.append('=');
-            stringBuilder.append(ShiroUtils.escape(JsonUtils.nodeToString(e.getValue())));
+            stringBuilder.append(ShiroUtils.escape(JsonUtils.nodeToString(v.getValue())));
         });
         stringBuilder.append(']');
         return stringBuilder.toString();

--- a/src/main/java/com/mikuac/shiro/properties/WebSocketServerProperties.java
+++ b/src/main/java/com/mikuac/shiro/properties/WebSocketServerProperties.java
@@ -26,9 +26,4 @@ public class WebSocketServerProperties {
      */
     private String url = "/ws/shiro";
 
-    /**
-     * 最大空闲时间，超过这个时间将关闭会话 15Min
-     */
-    private Long maxSessionIdleTimeout = 15 * 60 * 1000L;
-
 }

--- a/src/main/java/com/mikuac/shiro/task/ShiroAsyncTask.java
+++ b/src/main/java/com/mikuac/shiro/task/ShiroAsyncTask.java
@@ -1,6 +1,6 @@
 package com.mikuac.shiro.task;
 
-import com.alibaba.fastjson2.JSONObject;
+import com.mikuac.shiro.common.utils.JsonObjectWrapper;
 import com.mikuac.shiro.core.Bot;
 import com.mikuac.shiro.core.BotContainer;
 import com.mikuac.shiro.handler.EventHandler;
@@ -32,7 +32,7 @@ public class ShiroAsyncTask {
      * @param resp    上报的 Json 数据
      */
     @Async("shiroTaskExecutor")
-    public void execHandlerMsg(EventHandler event, long xSelfId, JSONObject resp) {
+    public void execHandlerMsg(EventHandler event, long xSelfId, JsonObjectWrapper resp) {
         Bot bot = botContainer.robots.get(xSelfId);
         if (bot != null) {
             event.handler(bot, resp);

--- a/src/test/java/com/mikuac/shiro/common/utils/JsonUtilsTest.java
+++ b/src/test/java/com/mikuac/shiro/common/utils/JsonUtilsTest.java
@@ -1,0 +1,55 @@
+package com.mikuac.shiro.common.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JsonUtilsTest {
+
+    @Test
+    void testParseToJsonNode_withValidJsonString() {
+        String json = "{\"name\":\"Alice\",\"age\":30}";
+        JsonNode node = JsonUtils.parseToJsonNode(json);
+        assertTrue(node.isObject());
+        assertEquals("Alice", node.get("name").asText());
+        assertEquals(30, node.get("age").asInt());
+    }
+
+    @Test
+    void testParseToJsonNode_withInvalidJsonString() {
+        String notJson = "Just a plain string";
+        JsonNode node = JsonUtils.parseToJsonNode(notJson);
+        assertInstanceOf(TextNode.class, node);
+        assertEquals(notJson, node.asText());
+    }
+
+    @Test
+    void testParseToJsonNode_withEmptyString() {
+        String empty = "";
+        JsonNode node = JsonUtils.parseToJsonNode(empty);
+        assertInstanceOf(TextNode.class, node);
+        assertEquals(empty, node.asText());
+    }
+
+    @Test
+    void testParseToJsonNode_withNonStringObject() {
+        Person person = new Person("Bob", 25);
+        JsonNode node = JsonUtils.parseToJsonNode(person);
+        assertTrue(node.isObject());
+        assertEquals("Bob", node.get("name").asText());
+        assertEquals(25, node.get("age").asInt());
+    }
+
+    static class Person {
+        public String name;
+        public int age;
+
+        public Person(String name, int age) {
+            this.name = name;
+            this.age = age;
+        }
+    }
+
+}

--- a/src/test/java/com/mikuac/shiro/common/utils/MessageConverserTest.java
+++ b/src/test/java/com/mikuac/shiro/common/utils/MessageConverserTest.java
@@ -69,8 +69,8 @@ class MessageConverserTest {
         val raw = "[CQ:at,qq=1122334455]";
         val originalResult = rawToArrayMsgOriginal(raw);
         val optimizedResult = MessageConverser.stringToArray(raw);
-        val originalCode = MessageConverser.arrayToString(originalResult.get(0));
-        val optimizedCode = MessageConverser.arrayToString(optimizedResult.get(0));
+        val originalCode = originalResult.get(0).toCQCode();
+        val optimizedCode = optimizedResult.get(0).toCQCode();
         assertEquals(raw, originalCode);
         assertEquals(raw, optimizedCode);
         assertEquals(originalResult, optimizedResult);


### PR DESCRIPTION
## Sourcery 总结

在整个代码库中将 fastjson2 替换为 Jackson，包括 action 和事件处理器、模型和响应 DTO、工具类以及注解，并移除 fastjson2 依赖。

新功能：
- 通过添加 `JsonUtils` 和 `JsonObjectWrapper` 类，集成 Jackson 作为主要的 JSON 库

改进：
- 将所有 JSON 解析和序列化从 `fastjson2` 迁移到 `Jackson`，并将 `JSONObject` 和 `fastjson` 注解替换为 `Jackson` 类型和 `@JsonProperty`

构建：
- 从构建配置中移除 `fastjson2` 依赖

测试：
- 添加 `JsonUtilsTest` 并更新 `MessageConverserTest`，以覆盖基于 Jackson 的 JSON 工具类

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace fastjson2 with Jackson across the codebase, including action and event handlers, model and response DTOs, utilities, and annotations, and remove the fastjson2 dependency.

New Features:
- Integrate Jackson as the primary JSON library by adding JsonUtils and JsonObjectWrapper classes

Enhancements:
- Migrate all JSON parsing and serialization from fastjson2 to Jackson, replacing JSONObject and fastjson annotations with Jackson types and @JsonProperty

Build:
- Remove fastjson2 dependency from the build configuration

Tests:
- Add JsonUtilsTest and update MessageConverserTest to cover Jackson‐based JSON utilities

</details>