### PR TITLE
Add MESSAGE_BLOCK support for plugins registered with @Shiro annotation

### DIFF
--- a/src/main/java/com/mikuac/shiro/handler/injection/InjectionHandler.java
+++ b/src/main/java/com/mikuac/shiro/handler/injection/InjectionHandler.java
@@ -44,15 +44,15 @@ public class InjectionHandler {
         Class<?>[] paramTypes = method.getMethod().getParameterTypes();
         Object[] args = new Object[paramTypes.length];
         Arrays.stream(paramTypes).forEach(InternalUtils.consumerWithIndex((paramType, index) -> args[index] = params.get(paramType)));
-        Object result = null;
+        Object invokeResult = null;
         try {
-            result = method.getMethod().invoke(method.getObject(), args);
+            invokeResult = method.getMethod().invoke(method.getObject(), args);
         } catch (Exception e) {
             String methodName = method.getMethod().getDeclaringClass().getSimpleName()
                     + "#" + method.getMethod().getName();
             log.error("Invoke method exception on [{}]: {}", methodName, e.getMessage(), e);
         }
-        return result;
+        return invokeResult;
     }
 
     private <T> void invoke(Bot bot, T event, Class<? extends Annotation> type) {
@@ -268,13 +268,13 @@ public class InjectionHandler {
         for (HandlerMethod method : handlerMethods.get()) {
             MessageHandlerFilter filter = method.getMethod().getAnnotation(MessageHandlerFilter.class);
             CheckResult result;
-            Object invoke = null;
+            Object invokeResult = null;
             if (Objects.isNull(filter)) {
-                invoke = invoke(bot, event, method, null);
+                invokeResult = invoke(bot, event, method, null);
             } else if ((result = CommonUtils.allFilterCheck(event, bot.getSelfId(), filter)).isResult()) {
-                invoke = invoke(bot, event, method, result.getMatcher());
+                invokeResult = invoke(bot, event, method, result.getMatcher());
             }
-            if (isBlockingResult(invoke)) break;
+            if (isBlockingResult(invokeResult)) break;
         }
     }
 

--- a/src/main/java/com/mikuac/shiro/handler/injection/InjectionHandler.java
+++ b/src/main/java/com/mikuac/shiro/handler/injection/InjectionHandler.java
@@ -5,6 +5,7 @@ import com.mikuac.shiro.common.utils.CheckResult;
 import com.mikuac.shiro.common.utils.CommonUtils;
 import com.mikuac.shiro.common.utils.InternalUtils;
 import com.mikuac.shiro.core.Bot;
+import com.mikuac.shiro.core.BotPlugin;
 import com.mikuac.shiro.dto.event.message.*;
 import com.mikuac.shiro.dto.event.meta.HeartbeatMetaEvent;
 import com.mikuac.shiro.dto.event.meta.LifecycleMetaEvent;
@@ -39,17 +40,19 @@ public class InjectionHandler {
      * @param method The handler method to invoke
      * @param params Map of available parameters for injection
      */
-    private void invokeMethod(HandlerMethod method, Map<Class<?>, Object> params) {
+    private Object invokeMethod(HandlerMethod method, Map<Class<?>, Object> params) {
         Class<?>[] paramTypes = method.getMethod().getParameterTypes();
         Object[] args = new Object[paramTypes.length];
         Arrays.stream(paramTypes).forEach(InternalUtils.consumerWithIndex((paramType, index) -> args[index] = params.get(paramType)));
+        Object result = null;
         try {
-            method.getMethod().invoke(method.getObject(), args);
+            result = method.getMethod().invoke(method.getObject(), args);
         } catch (Exception e) {
             String methodName = method.getMethod().getDeclaringClass().getSimpleName()
                     + "#" + method.getMethod().getName();
             log.error("Invoke method exception on [{}]: {}", methodName, e.getMessage(), e);
         }
+        return result;
     }
 
     private <T> void invoke(Bot bot, T event, Class<? extends Annotation> type) {
@@ -60,10 +63,12 @@ public class InjectionHandler {
         Map<Class<?>, Object> params = new HashMap<>();
         params.put(Bot.class, bot);
         params.put(event.getClass(), event);
-        methods.get().forEach(method -> invokeMethod(method, params));
+        for (HandlerMethod method : methods.get()) {
+            if (isBlockingResult(invokeMethod(method, params))) break;
+        }
     }
 
-    private <T> void invoke(Bot bot, T event, HandlerMethod method, Matcher matcher) {
+    private <T> Object invoke(Bot bot, T event, HandlerMethod method, Matcher matcher) {
         Map<Class<?>, Object> params = new HashMap<>();
         // 此处逻辑修改，因为如果包含 cmd 但是校验未通过，在之前就被拦截掉了，所以到达此处若 matcher 为空则说明 cmd 参数未填写，不影响参数传递。
         if (matcher != null) {
@@ -71,7 +76,7 @@ public class InjectionHandler {
         }
         params.put(Bot.class, bot);
         params.put(event.getClass(), event);
-        invokeMethod(method, params);
+        return invokeMethod(method, params);
     }
 
     /**
@@ -260,15 +265,17 @@ public class InjectionHandler {
         if (handlerMethods.isEmpty()) {
             return;
         }
-        handlerMethods.get().forEach(method -> {
+        for (HandlerMethod method : handlerMethods.get()) {
             MessageHandlerFilter filter = method.getMethod().getAnnotation(MessageHandlerFilter.class);
             CheckResult result;
+            Object invoke = null;
             if (Objects.isNull(filter)) {
-                invoke(bot, event, method, null);
+                invoke = invoke(bot, event, method, null);
             } else if ((result = CommonUtils.allFilterCheck(event, bot.getSelfId(), filter)).isResult()) {
-                invoke(bot, event, method, result.getMatcher());
+                invoke = invoke(bot, event, method, result.getMatcher());
             }
-        });
+            if (isBlockingResult(invoke)) break;
+        }
     }
 
     /**
@@ -343,6 +350,15 @@ public class InjectionHandler {
 
             invokeMethod(method, params);
         });
+    }
+
+    /**
+     * 判断是否为阻塞结果
+     */
+    private boolean isBlockingResult(Object result) {
+        if (result == null) return false;
+        if (result instanceof Boolean && Boolean.TRUE.equals(result)) return true;
+        return result.equals(BotPlugin.MESSAGE_BLOCK);
     }
 
 }


### PR DESCRIPTION
使通过 @Shiro 注解注册的处理程序能够通过返回 BotPlugin.MESSAGE_BLOCK 或 true 来停止后续事件执行

## 由 Sourcery 总结

允许使用 `@Shiro` 注解的插件通过返回 `MESSAGE_BLOCK` 或 `true` 来停止事件传播

新功能：
- 当处理程序返回 `BotPlugin.MESSAGE_BLOCK` 或 `true` 时，支持提前终止处理程序链

增强：
- 重构 `invokeMethod` 以返回处理程序方法的执行结果
- 更新事件调用循环，使其在使用 `isBlockingResult` 检测到阻塞结果时中断
- 引入 `isBlockingResult` 辅助方法，以集中处理阻塞结果的检测

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow plugins annotated with @Shiro to stop event propagation by returning MESSAGE_BLOCK or true

New Features:
- support early termination of handler chains when a handler returns BotPlugin.MESSAGE_BLOCK or true

Enhancements:
- refactor invokeMethod to return the handler method result
- update event invocation loops to break on blocking results using isBlockingResult
- introduce isBlockingResult helper to centralize blocking result detection

</details>