### PR TITLE
添加功能：消息表情回应 （NapCat）

### DIFF
--- a/src/main/java/com/mikuac/shiro/action/NapCatExtend.java
+++ b/src/main/java/com/mikuac/shiro/action/NapCatExtend.java
@@ -33,4 +33,14 @@ public interface NapCatExtend {
     ActionRaw sendFriendPoke(long userId);
 
     ActionRaw sendFriendPoke(long userId, long targetId);
+
+    /**
+     * 设置消息表情回应(贴表情)
+     *
+     * @param msgId 消息 ID
+     * @param code  表情 ID
+     * @param isSet 添加/取消 回应
+     * @return result {@link ActionRaw}
+     */
+    ActionRaw setMsgEmojiLike(int msgId, String code, boolean isSet);
 }

--- a/src/main/java/com/mikuac/shiro/annotation/MessageEmojiLikeNoticeHandler.java
+++ b/src/main/java/com/mikuac/shiro/annotation/MessageEmojiLikeNoticeHandler.java
@@ -1,0 +1,9 @@
+package com.mikuac.shiro.annotation;
+
+import java.lang.annotation.*;
+
+@Documented
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MessageEmojiLikeNoticeHandler {
+}

--- a/src/main/java/com/mikuac/shiro/constant/ActionParams.java
+++ b/src/main/java/com/mikuac/shiro/constant/ActionParams.java
@@ -114,4 +114,8 @@ public class ActionParams {
     public static final String SUMMARY = "summary";
 
     public static final String SOURCE = "source";
+
+    public static final String EMOJI_ID = "emoji_id";
+
+    public static final String SET = "set";
 }

--- a/src/main/java/com/mikuac/shiro/core/Bot.java
+++ b/src/main/java/com/mikuac/shiro/core/Bot.java
@@ -1567,6 +1567,24 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
     }
 
     /**
+     * 设置消息表情回应(贴表情)
+     *
+     * @param msgId 消息 ID
+     * @param code  表情 ID
+     * @param isSet 添加/取消 回应
+     * @return result {@link ActionRaw}
+     */
+    @Override
+    public ActionRaw setMsgEmojiLike(int msgId, String code, boolean isSet) {
+        Map<String, Object> params = new HashMap<>();
+        params.put(ActionParams.MESSAGE_ID, msgId);
+        params.put(ActionParams.EMOJI_ID, code);
+        params.put(ActionParams.SET, isSet);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SET_MSG_EMOJI_LIKE, params);
+        return result != null ? result.to(ActionRaw.class) : null;
+    }
+
+    /**
      * 获取合并转发消息
      *
      * @param msgId 消息ID

--- a/src/main/java/com/mikuac/shiro/core/BotPlugin.java
+++ b/src/main/java/com/mikuac/shiro/core/BotPlugin.java
@@ -304,4 +304,15 @@ public class BotPlugin {
         return MESSAGE_IGNORE;
     }
 
+    /**
+     * 消息表情回应
+     *
+     * @param bot   {@link Bot}
+     * @param event {@link MessageEmojiLikeNoticeEvent}
+     * @return 是否执行下一个插件，MESSAGE_IGNORE 向下执行，MESSAGE_BLOCK 不向下执行
+     */
+    public int onMessageEmojiLikeNotice(Bot bot, MessageEmojiLikeNoticeEvent event) {
+        return MESSAGE_IGNORE;
+    }
+
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/notice/MessageEmojiLikeNoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/notice/MessageEmojiLikeNoticeEvent.java
@@ -1,0 +1,48 @@
+package com.mikuac.shiro.dto.event.notice;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
+@EqualsAndHashCode(callSuper = true)
+public class MessageEmojiLikeNoticeEvent extends NoticeEvent {
+
+    /**
+     * 群组ID
+     */
+    @JsonProperty("group_id")
+    private Long groupId;
+
+    /**
+     * 消息ID
+     */
+    @JsonProperty("message_id")
+    private Integer messageId;
+
+    /**
+     * 操作者ID
+     */
+    @JsonProperty("operator_id")
+    private Long operatorId;
+
+    /**
+     * 表情ID
+     */
+    @JsonProperty("code")
+    private String code;
+
+    /**
+     * 表情数量
+     */
+    @JsonProperty("count")
+    private Integer count;
+
+}

--- a/src/main/java/com/mikuac/shiro/enums/ActionPathEnum.java
+++ b/src/main/java/com/mikuac/shiro/enums/ActionPathEnum.java
@@ -302,6 +302,10 @@ public enum ActionPathEnum implements ActionPath {
      * 设置群消息表情回应
      */
     SET_GROUP_REACTION("set_group_reaction"),
+    /**
+     * 设置群消息表情回应
+     */
+    SET_MSG_EMOJI_LIKE("set_msg_emoji_like"),
 
     /**
      * 获取合并转发消息

--- a/src/main/java/com/mikuac/shiro/enums/NoticeEventEnum.java
+++ b/src/main/java/com/mikuac/shiro/enums/NoticeEventEnum.java
@@ -65,5 +65,9 @@ public enum NoticeEventEnum {
     /**
      * 群消息表情贴
      */
-    GROUP_MESSAGE_REACTION
+    GROUP_MESSAGE_REACTION,
+    /**
+     * 消息表情回应
+     */
+    MESSAGE_EMOJI_LIKE
 }

--- a/src/main/java/com/mikuac/shiro/handler/EventHandler.java
+++ b/src/main/java/com/mikuac/shiro/handler/EventHandler.java
@@ -81,6 +81,7 @@ public class EventHandler implements ApplicationRunner {
         notice.handlers.put("channel_updated", notice::channelUpdated);
         notice.handlers.put("message_reactions_updated", notice::messageReactionsUpdated);
         notice.handlers.put("reaction", notice::groupReactionMessage);
+        notice.handlers.put("group_msg_emoji_like", notice::messageEmojiLikeMessage);
 
         // Register Notify Handler
         notify.handlers.put("poke", notify::poke);

--- a/src/main/java/com/mikuac/shiro/handler/event/NoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/handler/event/NoticeEvent.java
@@ -120,6 +120,12 @@ public class NoticeEvent {
             bot.getPluginList().stream().anyMatch(o -> utils.getPlugin(o).onGroupReactionNotice(bot, event) == BotPlugin.MESSAGE_BLOCK);
         }
 
+        if (type == NoticeEventEnum.MESSAGE_EMOJI_LIKE) {
+            MessageEmojiLikeNoticeEvent event = resp.to(MessageEmojiLikeNoticeEvent.class);
+            injection.invokeMessageEmojiLikeNotice(bot, event);
+            bot.getPluginList().stream().anyMatch(o -> utils.getPlugin(o).onMessageEmojiLikeNotice(bot, event) == BotPlugin.MESSAGE_BLOCK);
+        }
+
         if (type == NoticeEventEnum.OFFLINE_FILE) {
             ReceiveOfflineFilesNoticeEvent event = resp.to(ReceiveOfflineFilesNoticeEvent.class);
             bot.getPluginList().stream().anyMatch(o -> utils.getPlugin(o).onReceiveOfflineFilesNotice(bot, event) == BotPlugin.MESSAGE_BLOCK);
@@ -302,6 +308,16 @@ public class NoticeEvent {
      */
     public void groupReactionMessage(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, NoticeEventEnum.GROUP_MESSAGE_REACTION);
+    }
+
+    /**
+     * 消息表情回应
+     *
+     * @param bot  {@link Bot}
+     * @param resp {@link JsonObjectWrapper}
+     */
+    public void messageEmojiLikeMessage(Bot bot, JsonObjectWrapper resp) {
+        process(bot, resp, NoticeEventEnum.MESSAGE_EMOJI_LIKE);
     }
 
 }

--- a/src/main/java/com/mikuac/shiro/handler/injection/InjectionHandler.java
+++ b/src/main/java/com/mikuac/shiro/handler/injection/InjectionHandler.java
@@ -210,6 +210,16 @@ public class InjectionHandler {
     }
 
     /**
+     * 消息表情回应事件
+     *
+     * @param bot   {@link Bot}
+     * @param event {@link MessageEmojiLikeNoticeEvent}
+     */
+    public void invokeMessageEmojiLikeNotice(Bot bot, MessageEmojiLikeNoticeEvent event) {
+        invoke(bot, event, MessageEmojiLikeNoticeHandler.class);
+    }
+
+    /**
      * 监听全部消息
      *
      * @param bot   {@link Bot}

--- a/src/main/java/com/mikuac/shiro/handler/injection/InjectionHandler.java
+++ b/src/main/java/com/mikuac/shiro/handler/injection/InjectionHandler.java
@@ -44,15 +44,15 @@ public class InjectionHandler {
         Class<?>[] paramTypes = method.getMethod().getParameterTypes();
         Object[] args = new Object[paramTypes.length];
         Arrays.stream(paramTypes).forEach(InternalUtils.consumerWithIndex((paramType, index) -> args[index] = params.get(paramType)));
-        Object result = null;
+        Object invokeResult = null;
         try {
-            result = method.getMethod().invoke(method.getObject(), args);
+            invokeResult = method.getMethod().invoke(method.getObject(), args);
         } catch (Exception e) {
             String methodName = method.getMethod().getDeclaringClass().getSimpleName()
                     + "#" + method.getMethod().getName();
             log.error("Invoke method exception on [{}]: {}", methodName, e.getMessage(), e);
         }
-        return result;
+        return invokeResult;
     }
 
     private <T> void invoke(Bot bot, T event, Class<? extends Annotation> type) {
@@ -268,13 +268,13 @@ public class InjectionHandler {
         for (HandlerMethod method : handlerMethods.get()) {
             MessageHandlerFilter filter = method.getMethod().getAnnotation(MessageHandlerFilter.class);
             CheckResult result;
-            Object invoke = null;
+            Object invokeResult = null;
             if (Objects.isNull(filter)) {
-                invoke = invoke(bot, event, method, null);
+                invokeResult = invoke(bot, event, method, null);
             } else if ((result = CommonUtils.allFilterCheck(event, bot.getSelfId(), filter)).isResult()) {
-                invoke = invoke(bot, event, method, result.getMatcher());
+                invokeResult = invoke(bot, event, method, result.getMatcher());
             }
-            if (isBlockingResult(invoke)) break;
+            if (isBlockingResult(invokeResult)) break;
         }
     }
 

--- a/src/main/java/com/mikuac/shiro/handler/injection/InjectionHandler.java
+++ b/src/main/java/com/mikuac/shiro/handler/injection/InjectionHandler.java
@@ -5,6 +5,7 @@ import com.mikuac.shiro.common.utils.CheckResult;
 import com.mikuac.shiro.common.utils.CommonUtils;
 import com.mikuac.shiro.common.utils.InternalUtils;
 import com.mikuac.shiro.core.Bot;
+import com.mikuac.shiro.core.BotPlugin;
 import com.mikuac.shiro.dto.event.message.*;
 import com.mikuac.shiro.dto.event.meta.HeartbeatMetaEvent;
 import com.mikuac.shiro.dto.event.meta.LifecycleMetaEvent;
@@ -39,17 +40,19 @@ public class InjectionHandler {
      * @param method The handler method to invoke
      * @param params Map of available parameters for injection
      */
-    private void invokeMethod(HandlerMethod method, Map<Class<?>, Object> params) {
+    private Object invokeMethod(HandlerMethod method, Map<Class<?>, Object> params) {
         Class<?>[] paramTypes = method.getMethod().getParameterTypes();
         Object[] args = new Object[paramTypes.length];
         Arrays.stream(paramTypes).forEach(InternalUtils.consumerWithIndex((paramType, index) -> args[index] = params.get(paramType)));
+        Object result = null;
         try {
-            method.getMethod().invoke(method.getObject(), args);
+            result = method.getMethod().invoke(method.getObject(), args);
         } catch (Exception e) {
             String methodName = method.getMethod().getDeclaringClass().getSimpleName()
                     + "#" + method.getMethod().getName();
             log.error("Invoke method exception on [{}]: {}", methodName, e.getMessage(), e);
         }
+        return result;
     }
 
     private <T> void invoke(Bot bot, T event, Class<? extends Annotation> type) {
@@ -60,10 +63,12 @@ public class InjectionHandler {
         Map<Class<?>, Object> params = new HashMap<>();
         params.put(Bot.class, bot);
         params.put(event.getClass(), event);
-        methods.get().forEach(method -> invokeMethod(method, params));
+        for (HandlerMethod method : methods.get()) {
+            if (isBlockingResult(invokeMethod(method, params))) break;
+        }
     }
 
-    private <T> void invoke(Bot bot, T event, HandlerMethod method, Matcher matcher) {
+    private <T> Object invoke(Bot bot, T event, HandlerMethod method, Matcher matcher) {
         Map<Class<?>, Object> params = new HashMap<>();
         // 此处逻辑修改，因为如果包含 cmd 但是校验未通过，在之前就被拦截掉了，所以到达此处若 matcher 为空则说明 cmd 参数未填写，不影响参数传递。
         if (matcher != null) {
@@ -71,7 +76,7 @@ public class InjectionHandler {
         }
         params.put(Bot.class, bot);
         params.put(event.getClass(), event);
-        invokeMethod(method, params);
+        return invokeMethod(method, params);
     }
 
     /**
@@ -260,15 +265,17 @@ public class InjectionHandler {
         if (handlerMethods.isEmpty()) {
             return;
         }
-        handlerMethods.get().forEach(method -> {
+        for (HandlerMethod method : handlerMethods.get()) {
             MessageHandlerFilter filter = method.getMethod().getAnnotation(MessageHandlerFilter.class);
             CheckResult result;
+            Object invoke = null;
             if (Objects.isNull(filter)) {
-                invoke(bot, event, method, null);
+                invoke = invoke(bot, event, method, null);
             } else if ((result = CommonUtils.allFilterCheck(event, bot.getSelfId(), filter)).isResult()) {
-                invoke(bot, event, method, result.getMatcher());
+                invoke = invoke(bot, event, method, result.getMatcher());
             }
-        });
+            if (isBlockingResult(invoke)) break;
+        }
     }
 
     /**
@@ -343,6 +350,15 @@ public class InjectionHandler {
 
             invokeMethod(method, params);
         });
+    }
+
+    /**
+     * 判断是否为阻塞结果
+     */
+    private boolean isBlockingResult(Object result) {
+        if (result == null) return false;
+        if (result instanceof Boolean && Boolean.TRUE.equals(result)) return true;
+        return result.equals(BotPlugin.MESSAGE_BLOCK);
     }
 
 }


### PR DESCRIPTION
## Sourcery 总结

增加对消息表情点赞（反应）事件和 API 的支持，并增强注入框架以尊重阻塞插件的结果

新功能：
- 引入 MessageEmojiLikeNoticeEvent DTO 和相应的 @MessageEmojiLikeNoticeHandler 来处理表情点赞通知
- 添加 Bot.setMsgEmojiLike 方法和 NapCatExtend 接口入口，用于添加或移除消息表情反应

增强：
- 更新 InjectionHandler 以返回调用结果并在阻塞响应时停止后续处理器
- 扩展 ActionParams, ActionPathEnum, NoticeEventEnum 和 EventHandler 映射，以支持新的表情点赞通知事件

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for message emoji like (reaction) events and API, and enhance the injection framework to respect blocking plugin results

New Features:
- Introduce MessageEmojiLikeNoticeEvent DTO and corresponding @MessageEmojiLikeNoticeHandler to process emoji-like notices
- Add Bot.setMsgEmojiLike method and NapCatExtend interface entry for adding or removing message emoji reactions

Enhancements:
- Update InjectionHandler to return invocation results and halt further handlers on blocking responses
- Extend ActionParams, ActionPathEnum, NoticeEventEnum, and EventHandler mapping to support the new emoji-like notice event

</details>