### PR TITLE
:sparkles: Add support for msg emoji like api (NapCat)

### DIFF
--- a/src/main/java/com/mikuac/shiro/action/NapCatExtend.java
+++ b/src/main/java/com/mikuac/shiro/action/NapCatExtend.java
@@ -33,4 +33,14 @@ public interface NapCatExtend {
     ActionRaw sendFriendPoke(long userId);
 
     ActionRaw sendFriendPoke(long userId, long targetId);
+
+    /**
+     * 设置消息表情回应(贴表情)
+     *
+     * @param msgId 消息 ID
+     * @param code  表情 ID
+     * @param isSet 添加/取消 回应
+     * @return result {@link ActionRaw}
+     */
+    ActionRaw setMsgEmojiLike(int msgId, String code, boolean isSet);
 }

--- a/src/main/java/com/mikuac/shiro/annotation/MessageEmojiLikeNoticeHandler.java
+++ b/src/main/java/com/mikuac/shiro/annotation/MessageEmojiLikeNoticeHandler.java
@@ -1,0 +1,9 @@
+package com.mikuac.shiro.annotation;
+
+import java.lang.annotation.*;
+
+@Documented
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MessageEmojiLikeNoticeHandler {
+}

--- a/src/main/java/com/mikuac/shiro/constant/ActionParams.java
+++ b/src/main/java/com/mikuac/shiro/constant/ActionParams.java
@@ -114,4 +114,8 @@ public class ActionParams {
     public static final String SUMMARY = "summary";
 
     public static final String SOURCE = "source";
+
+    public static final String EMOJI_ID = "emoji_id";
+
+    public static final String SET = "set";
 }

--- a/src/main/java/com/mikuac/shiro/core/Bot.java
+++ b/src/main/java/com/mikuac/shiro/core/Bot.java
@@ -1567,6 +1567,24 @@ public class Bot implements OneBot, GoCQHTTPExtend, GensokyoExtend, LagrangeExte
     }
 
     /**
+     * 设置消息表情回应(贴表情)
+     *
+     * @param msgId 消息 ID
+     * @param code  表情 ID
+     * @param isSet 添加/取消 回应
+     * @return result {@link ActionRaw}
+     */
+    @Override
+    public ActionRaw setMsgEmojiLike(int msgId, String code, boolean isSet) {
+        Map<String, Object> params = new HashMap<>();
+        params.put(ActionParams.MESSAGE_ID, msgId);
+        params.put(ActionParams.EMOJI_ID, code);
+        params.put(ActionParams.SET, isSet);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SET_MSG_EMOJI_LIKE, params);
+        return result != null ? result.to(ActionRaw.class) : null;
+    }
+
+    /**
      * 获取合并转发消息
      *
      * @param msgId 消息ID

--- a/src/main/java/com/mikuac/shiro/core/BotPlugin.java
+++ b/src/main/java/com/mikuac/shiro/core/BotPlugin.java
@@ -304,4 +304,15 @@ public class BotPlugin {
         return MESSAGE_IGNORE;
     }
 
+    /**
+     * 消息表情回应
+     *
+     * @param bot   {@link Bot}
+     * @param event {@link MessageEmojiLikeNoticeEvent}
+     * @return 是否执行下一个插件，MESSAGE_IGNORE 向下执行，MESSAGE_BLOCK 不向下执行
+     */
+    public int onMessageEmojiLikeNotice(Bot bot, MessageEmojiLikeNoticeEvent event) {
+        return MESSAGE_IGNORE;
+    }
+
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/notice/MessageEmojiLikeNoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/notice/MessageEmojiLikeNoticeEvent.java
@@ -1,0 +1,48 @@
+package com.mikuac.shiro.dto.event.notice;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
+@EqualsAndHashCode(callSuper = true)
+public class MessageEmojiLikeNoticeEvent extends NoticeEvent {
+
+    /**
+     * 群组ID
+     */
+    @JsonProperty("group_id")
+    private Long groupId;
+
+    /**
+     * 消息ID
+     */
+    @JsonProperty("message_id")
+    private Integer messageId;
+
+    /**
+     * 操作者ID
+     */
+    @JsonProperty("operator_id")
+    private Long operatorId;
+
+    /**
+     * 表情ID
+     */
+    @JsonProperty("code")
+    private String code;
+
+    /**
+     * 表情数量
+     */
+    @JsonProperty("count")
+    private Integer count;
+
+}

--- a/src/main/java/com/mikuac/shiro/enums/ActionPathEnum.java
+++ b/src/main/java/com/mikuac/shiro/enums/ActionPathEnum.java
@@ -302,6 +302,10 @@ public enum ActionPathEnum implements ActionPath {
      * 设置群消息表情回应
      */
     SET_GROUP_REACTION("set_group_reaction"),
+    /**
+     * 设置群消息表情回应
+     */
+    SET_MSG_EMOJI_LIKE("set_msg_emoji_like"),
 
     /**
      * 获取合并转发消息

--- a/src/main/java/com/mikuac/shiro/enums/NoticeEventEnum.java
+++ b/src/main/java/com/mikuac/shiro/enums/NoticeEventEnum.java
@@ -65,5 +65,9 @@ public enum NoticeEventEnum {
     /**
      * 群消息表情贴
      */
-    GROUP_MESSAGE_REACTION
+    GROUP_MESSAGE_REACTION,
+    /**
+     * 消息表情回应
+     */
+    MESSAGE_EMOJI_LIKE
 }

--- a/src/main/java/com/mikuac/shiro/handler/EventHandler.java
+++ b/src/main/java/com/mikuac/shiro/handler/EventHandler.java
@@ -81,6 +81,7 @@ public class EventHandler implements ApplicationRunner {
         notice.handlers.put("channel_updated", notice::channelUpdated);
         notice.handlers.put("message_reactions_updated", notice::messageReactionsUpdated);
         notice.handlers.put("reaction", notice::groupReactionMessage);
+        notice.handlers.put("group_msg_emoji_like", notice::messageEmojiLikeMessage);
 
         // Register Notify Handler
         notify.handlers.put("poke", notify::poke);

--- a/src/main/java/com/mikuac/shiro/handler/event/NoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/handler/event/NoticeEvent.java
@@ -120,6 +120,12 @@ public class NoticeEvent {
             bot.getPluginList().stream().anyMatch(o -> utils.getPlugin(o).onGroupReactionNotice(bot, event) == BotPlugin.MESSAGE_BLOCK);
         }
 
+        if (type == NoticeEventEnum.MESSAGE_EMOJI_LIKE) {
+            MessageEmojiLikeNoticeEvent event = resp.to(MessageEmojiLikeNoticeEvent.class);
+            injection.invokeMessageEmojiLikeNotice(bot, event);
+            bot.getPluginList().stream().anyMatch(o -> utils.getPlugin(o).onMessageEmojiLikeNotice(bot, event) == BotPlugin.MESSAGE_BLOCK);
+        }
+
         if (type == NoticeEventEnum.OFFLINE_FILE) {
             ReceiveOfflineFilesNoticeEvent event = resp.to(ReceiveOfflineFilesNoticeEvent.class);
             bot.getPluginList().stream().anyMatch(o -> utils.getPlugin(o).onReceiveOfflineFilesNotice(bot, event) == BotPlugin.MESSAGE_BLOCK);
@@ -302,6 +308,16 @@ public class NoticeEvent {
      */
     public void groupReactionMessage(Bot bot, JsonObjectWrapper resp) {
         process(bot, resp, NoticeEventEnum.GROUP_MESSAGE_REACTION);
+    }
+
+    /**
+     * 消息表情回应
+     *
+     * @param bot  {@link Bot}
+     * @param resp {@link JsonObjectWrapper}
+     */
+    public void messageEmojiLikeMessage(Bot bot, JsonObjectWrapper resp) {
+        process(bot, resp, NoticeEventEnum.MESSAGE_EMOJI_LIKE);
     }
 
 }

--- a/src/main/java/com/mikuac/shiro/handler/injection/InjectionHandler.java
+++ b/src/main/java/com/mikuac/shiro/handler/injection/InjectionHandler.java
@@ -210,6 +210,16 @@ public class InjectionHandler {
     }
 
     /**
+     * 消息表情回应事件
+     *
+     * @param bot   {@link Bot}
+     * @param event {@link MessageEmojiLikeNoticeEvent}
+     */
+    public void invokeMessageEmojiLikeNotice(Bot bot, MessageEmojiLikeNoticeEvent event) {
+        invoke(bot, event, MessageEmojiLikeNoticeHandler.class);
+    }
+
+    /**
      * 监听全部消息
      *
      * @param bot   {@link Bot}


### PR DESCRIPTION
## Sourcery 总结

通过添加 `setMsgEmojiLike` API、连接 `MESSAGE_EMOJI_LIKE` 通知事件处理，并暴露一个插件钩子用于自定义处理，实现对消息表情符号点赞（如 NapCat）的支持。

新特性：
- 添加 `setMsgEmojiLike` 动作，允许在消息上添加或移除表情符号反应
- 引入 `MESSAGE_EMOJI_LIKE` 通知事件，包括其 DTO、处理程序注解、枚举条目和插件钩子 `onMessageEmojiLikeNotice`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement support for message emoji like (NapCat) by adding the setMsgEmojiLike API, wiring up event handling for MESSAGE_EMOJI_LIKE notices, and exposing a plugin hook for custom handling.

New Features:
- Add setMsgEmojiLike action to allow adding or removing emoji reactions on messages
- Introduce MESSAGE_EMOJI_LIKE notice event with its DTO, handler annotation, enum entry, and plugin hook onMessageEmojiLikeNotice

</details>