### PR TITLE
Fix Reconnect function

### DIFF
--- a/src/main/java/com/mikuac/shiro/boot/ShiroAutoConfiguration.java
+++ b/src/main/java/com/mikuac/shiro/boot/ShiroAutoConfiguration.java
@@ -104,7 +104,7 @@ public class ShiroAutoConfiguration implements WebSocketConfigurer {
         manager.setHeaders(headers);
         manager.setAutoStartup(true);
 
-        scheduledTask.executor().scheduleAtFixedRate(() -> {
+        scheduledTask.executor().scheduleWithFixedDelay(() -> {
             if (!manager.isConnected()) {
                 manager.startInternal();
             }


### PR DESCRIPTION
修复ws重连功能无效bug

## Sourcery 总结

错误修复：
- WebSocket 客户端的重连任务使用 `scheduleWithFixedDelay` 代替 `scheduleAtFixedRate`，以恢复自动重连功能

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Use scheduleWithFixedDelay instead of scheduleAtFixedRate for the websocket client's reconnect task to restore automatic reconnection functionality

</details>