### PR TITLE
:bug: Incorrect structure of emoji details (likes) in MessageEmojiLikeNoticeEvent; Message blocking was not working perfectly.

### DIFF
--- a/src/main/java/com/mikuac/shiro/common/utils/EventUtils.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/EventUtils.java
@@ -87,20 +87,23 @@ public class EventUtils {
      * @param bot      {@link Bot}
      * @param resp     {@link JsonObjectWrapper}
      * @param arrayMsg {@link ArrayMsg}
+     * @return 是否中断向下执行
      */
-    public void pushAnyMessageEvent(Bot bot, JsonObjectWrapper resp, List<ArrayMsg> arrayMsg) {
+    public boolean pushAnyMessageEvent(Bot bot, JsonObjectWrapper resp, List<ArrayMsg> arrayMsg) {
         try {
             AnyMessageEvent event = resp.to(AnyMessageEvent.class);
             event.setArrayMsg(arrayMsg);
-            injection.invokeAnyMessage(bot, event);
+            boolean messageBlocked = injection.invokeAnyMessage(bot, event);
+            if (messageBlocked) return true;
             for (Class<? extends BotPlugin> pluginClass : bot.getPluginList()) {
                 if (getPlugin(pluginClass).onAnyMessage(bot, event) == BotPlugin.MESSAGE_BLOCK) {
-                    break;
+                    return true;
                 }
             }
         } catch (Exception e) {
             log.error("An exception occurred while pushing the message event: {}", e.getMessage(), e);
         }
+        return false;
     }
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/notice/GroupMessageReactionNoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/notice/GroupMessageReactionNoticeEvent.java
@@ -44,13 +44,13 @@ public class GroupMessageReactionNoticeEvent extends NoticeEvent {
     private String subType;
 
     /**
-     * 操作者ID
+     * 表情ID
      */
     @JsonProperty("code")
     private String code;
 
     /**
-     * 操作者ID
+     * 表情数量
      */
     @JsonProperty("count")
     private Integer count;

--- a/src/main/java/com/mikuac/shiro/dto/event/notice/MessageEmojiLikeNoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/notice/MessageEmojiLikeNoticeEvent.java
@@ -34,15 +34,27 @@ public class MessageEmojiLikeNoticeEvent extends NoticeEvent {
     private Long operatorId;
 
     /**
-     * 表情ID
+     * 表情详情
      */
-    @JsonProperty("code")
-    private String code;
+    @JsonProperty("likes")
+    private Likes likes;
 
-    /**
-     * 表情数量
-     */
-    @JsonProperty("count")
-    private Integer count;
+
+    @Data
+    public static class Likes {
+
+        /**
+         * 表情ID
+         */
+        @JsonProperty("emoji_id")
+        private String emojiId;
+
+        /**
+         * 表情数量
+         */
+        @JsonProperty("count")
+        private Integer count;
+
+    }
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/notice/MessageEmojiLikeNoticeEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/notice/MessageEmojiLikeNoticeEvent.java
@@ -7,6 +7,8 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.util.List;
+
 
 @Data
 @NoArgsConstructor
@@ -37,11 +39,11 @@ public class MessageEmojiLikeNoticeEvent extends NoticeEvent {
      * 表情详情
      */
     @JsonProperty("likes")
-    private Likes likes;
+    private List<Like> likes;
 
 
     @Data
-    public static class Likes {
+    public static class Like {
 
         /**
          * 表情ID

--- a/src/main/java/com/mikuac/shiro/handler/event/MessageEvent.java
+++ b/src/main/java/com/mikuac/shiro/handler/event/MessageEvent.java
@@ -75,9 +75,13 @@ public class MessageEvent {
                     return;
                 }
                 resp.put("message", event.getMessage());
-                utils.pushAnyMessageEvent(bot, resp, event.getArrayMsg());
-                injection.invokePrivateMessage(bot, event);
-                bot.getPluginList().stream().anyMatch(o -> utils.getPlugin(o).onPrivateMessage(bot, event) == BotPlugin.MESSAGE_BLOCK);
+                boolean messageBlocked = utils.pushAnyMessageEvent(bot, resp, event.getArrayMsg());
+                if (!messageBlocked) {
+                    messageBlocked = injection.invokePrivateMessage(bot, event);
+                }
+                if (!messageBlocked) {
+                    bot.getPluginList().stream().anyMatch(o -> utils.getPlugin(o).onPrivateMessage(bot, event) == BotPlugin.MESSAGE_BLOCK);
+                }
                 utils.getInterceptor(bot.getBotMessageEventInterceptor()).afterCompletion(bot, event);
             }
 
@@ -97,9 +101,13 @@ public class MessageEvent {
                     return;
                 }
                 resp.put("message", event.getMessage());
-                utils.pushAnyMessageEvent(bot, resp, event.getArrayMsg());
-                injection.invokeGroupMessage(bot, event);
-                bot.getPluginList().stream().anyMatch(o -> utils.getPlugin(o).onGroupMessage(bot, event) == BotPlugin.MESSAGE_BLOCK);
+                boolean messageBlocked = utils.pushAnyMessageEvent(bot, resp, event.getArrayMsg());
+                if (!messageBlocked) {
+                    messageBlocked = injection.invokeGroupMessage(bot, event);
+                }
+                if (!messageBlocked) {
+                    bot.getPluginList().stream().anyMatch(o -> utils.getPlugin(o).onGroupMessage(bot, event) == BotPlugin.MESSAGE_BLOCK);
+                }
                 utils.getInterceptor(bot.getBotMessageEventInterceptor()).afterCompletion(bot, event);
             }
 
@@ -108,8 +116,10 @@ public class MessageEvent {
                 if (utils.setInterceptor(bot, event)) {
                     return;
                 }
-                injection.invokeGuildMessage(bot, event);
-                bot.getPluginList().stream().anyMatch(o -> utils.getPlugin(o).onGuildMessage(bot, event) == BotPlugin.MESSAGE_BLOCK);
+                boolean messageBlocked = injection.invokeGuildMessage(bot, event);
+                if (!messageBlocked) {
+                    bot.getPluginList().stream().anyMatch(o -> utils.getPlugin(o).onGuildMessage(bot, event) == BotPlugin.MESSAGE_BLOCK);
+                }
                 utils.getInterceptor(bot.getBotMessageEventInterceptor()).afterCompletion(bot, event);
             }
         } catch (Exception e) {

--- a/src/main/java/com/mikuac/shiro/handler/injection/InjectionHandler.java
+++ b/src/main/java/com/mikuac/shiro/handler/injection/InjectionHandler.java
@@ -224,10 +224,11 @@ public class InjectionHandler {
      *
      * @param bot   {@link Bot}
      * @param event {@link AnyMessageEvent}
+     * @return 是否中断向下执行
      */
-    public void invokeAnyMessage(Bot bot, AnyMessageEvent event) {
+    public boolean invokeAnyMessage(Bot bot, AnyMessageEvent event) {
         Optional<List<HandlerMethod>> methods = Optional.ofNullable(bot.getAnnotationHandler().get(AnyMessageHandler.class));
-        invokeMessage(bot, event, methods);
+        return invokeMessage(bot, event, methods);
     }
 
     /**
@@ -235,10 +236,11 @@ public class InjectionHandler {
      *
      * @param bot   {@link Bot}
      * @param event {@link GuildMessageEvent}
+     * @return 是否中断向下执行
      */
-    public void invokeGuildMessage(Bot bot, GuildMessageEvent event) {
+    public boolean invokeGuildMessage(Bot bot, GuildMessageEvent event) {
         Optional<List<HandlerMethod>> methods = Optional.ofNullable(bot.getAnnotationHandler().get(GuildMessageHandler.class));
-        invokeMessage(bot, event, methods);
+        return invokeMessage(bot, event, methods);
     }
 
     /**
@@ -246,10 +248,11 @@ public class InjectionHandler {
      *
      * @param bot   {@link Bot}
      * @param event {@link GroupMessageEvent}
+     * @return 是否中断向下执行
      */
-    public void invokeGroupMessage(Bot bot, GroupMessageEvent event) {
+    public boolean invokeGroupMessage(Bot bot, GroupMessageEvent event) {
         Optional<List<HandlerMethod>> methods = Optional.ofNullable(bot.getAnnotationHandler().get(GroupMessageHandler.class));
-        invokeMessage(bot, event, methods);
+        return invokeMessage(bot, event, methods);
     }
 
     /**
@@ -257,10 +260,11 @@ public class InjectionHandler {
      *
      * @param bot   {@link Bot}
      * @param event {@link PrivateMessageEvent}
+     * @return 是否中断向下执行
      */
-    public void invokePrivateMessage(Bot bot, PrivateMessageEvent event) {
+    public boolean invokePrivateMessage(Bot bot, PrivateMessageEvent event) {
         Optional<List<HandlerMethod>> methods = Optional.ofNullable(bot.getAnnotationHandler().get(PrivateMessageHandler.class));
-        invokeMessage(bot, event, methods);
+        return invokeMessage(bot, event, methods);
     }
 
     /**
@@ -269,11 +273,12 @@ public class InjectionHandler {
      * @param bot            {@link Bot}
      * @param event          {@link MessageEvent}
      * @param handlerMethods 消息处理方法
+     * @return 是否中断向下执行
      */
     @SuppressWarnings("squid:S1121")
-    public void invokeMessage(Bot bot, MessageEvent event, Optional<List<HandlerMethod>> handlerMethods) {
+    public boolean invokeMessage(Bot bot, MessageEvent event, Optional<List<HandlerMethod>> handlerMethods) {
         if (handlerMethods.isEmpty()) {
-            return;
+            return false;
         }
         for (HandlerMethod method : handlerMethods.get()) {
             MessageHandlerFilter filter = method.getMethod().getAnnotation(MessageHandlerFilter.class);
@@ -284,8 +289,9 @@ public class InjectionHandler {
             } else if ((result = CommonUtils.allFilterCheck(event, bot.getSelfId(), filter)).isResult()) {
                 invokeResult = invoke(bot, event, method, result.getMatcher());
             }
-            if (isBlockingResult(invokeResult)) break;
+            if (isBlockingResult(invokeResult)) return true;
         }
+        return false;
     }
 
     /**


### PR DESCRIPTION
## Sourcery 总结

修复 MessageEmojiLikeNoticeEvent 中的表情符号详细结构，并通过重构处理程序调用方法以支持可中断的事件处理来改进消息阻塞功能。

Bug 修复：
- 重新设计 MessageEmojiLikeNoticeEvent，将表情符号 ID 和计数封装到一个嵌套的 Likes 类中，而不是独立的字段
- 修正 GroupMessageReactionNoticeEvent 中表情符号 ID 和计数的 Javadoc 注解

改进：
- 重构注入处理程序方法，使其返回一个布尔值以指示是否停止进一步的消息处理
- 更新 MessageEvent 和 EventUtils，以检查消息阻塞标志并在请求时停止传播

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix emoji detail structure in MessageEmojiLikeNoticeEvent and improve message blocking functionality by refactoring handler invocation methods to support interruptible event processing.

Bug Fixes:
- Redesign MessageEmojiLikeNoticeEvent to wrap emoji id and count into a nested Likes class instead of separate fields
- Correct Javadoc annotations for emoji id and count in GroupMessageReactionNoticeEvent

Enhancements:
- Refactor injection handler methods to return a boolean indicating whether to halt further message processing
- Update MessageEvent and EventUtils to check message-blocking flags and stop propagation when requested

</details>