### PR TITLE
增加了shiro对虚拟线程池的支持，增加了plainText字段了，优化了消息的正则匹配逻辑以可以只匹配纯文本消息

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@
 import org.jreleaser.model.Active
 
 group = "com.mikuac"
-version = "2.5.3"
+version = "2.5.4"
 
 val mavenArtifactResolver = "1.9.24"
 val mavenResolverProvider = "3.9.12"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@
 import org.jreleaser.model.Active
 
 group = "com.mikuac"
-version = "2.5.4"
+version = "2.5.5"
 
 val mavenArtifactResolver = "1.9.24"
 val mavenResolverProvider = "3.9.12"

--- a/src/main/java/com/mikuac/shiro/annotation/MessageHandlerFilter.java
+++ b/src/main/java/com/mikuac/shiro/annotation/MessageHandlerFilter.java
@@ -93,9 +93,9 @@ public @interface MessageHandlerFilter {
     boolean invert() default false;
 
     /**
-     * 仅匹配纯文本消息, 即不包含任何 CQ 码的消息，默认开启
+     * 仅匹配纯文本消息, 即不包含任何 CQ 码的消息，默认关闭
      * @return true 仅匹配纯文本消息
      */
-    boolean matchPlainText() default true;
+    boolean matchPlainText() default false;
 
 }

--- a/src/main/java/com/mikuac/shiro/annotation/MessageHandlerFilter.java
+++ b/src/main/java/com/mikuac/shiro/annotation/MessageHandlerFilter.java
@@ -92,4 +92,10 @@ public @interface MessageHandlerFilter {
      */
     boolean invert() default false;
 
+    /**
+     * 仅匹配纯文本消息, 即不包含任何 CQ 码的消息，默认开启
+     * @return true 仅匹配纯文本消息
+     */
+    boolean matchPlainText() default true;
+
 }

--- a/src/main/java/com/mikuac/shiro/common/utils/CommonUtils.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/CommonUtils.java
@@ -69,11 +69,10 @@ public class CommonUtils {
     @SuppressWarnings({"squid:S3776", "squid:S1121", "java:S6541"})
     private static CheckResult filterCheck(MessageEvent event, long selfId, MessageHandlerFilter filter) {
         Optional<Matcher> matcherOptional = Optional.empty();
-        String rawMessage = msgExtract(event.getRawMessage(), event.getArrayMsg(), filter.at(), event.getSelfId());
-        String message = event.getMessage();
+        String rawMessage = msgExtract(event.getMessage(), event.getArrayMsg(), filter.at(), event.getSelfId());
 
         // 检查 正则
-        if (!filter.cmd().isBlank() && (matcherOptional = RegexUtils.matcher(filter.cmd(), message)).isEmpty()) {
+        if (!filter.cmd().isBlank() && (matcherOptional = RegexUtils.matcher(filter.cmd(), filter.matchPlainText() ? event.getPlainText() : rawMessage)).isEmpty()) {
             return new CheckResult();
         }
 

--- a/src/main/java/com/mikuac/shiro/common/utils/MessageConverser.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/MessageConverser.java
@@ -18,7 +18,7 @@ public class MessageConverser {
     public static String arraysToString(List<ArrayMsg> array) {
         StringBuilder builder = new StringBuilder();
         for (ArrayMsg item : array) {
-            if (MsgTypeEnum.text.equals(item.getType())) {
+            if (!MsgTypeEnum.text.equals(item.getType())) {
                 builder.append(item.toCQCode());
             } else {
                 builder.append(item.getStringData(MsgTypeEnum.text.toString()));
@@ -26,6 +26,7 @@ public class MessageConverser {
         }
         return builder.toString();
     }
+
 
     @SuppressWarnings({"java:S6541", "java:S3776"})
     public static List<ArrayMsg> stringToArray(@NonNull String msg) {
@@ -145,6 +146,34 @@ public class MessageConverser {
         data.put("text", ShiroUtils.unescape(text));
         item.setData(data);
         chain.add(item);
+    }
+
+    /**
+     * 将消息数组转换为纯文本
+     * @param array 消息数组
+     * @return 纯文本消息
+     */
+    public static String arrayToPlainText(List<ArrayMsg> array) {
+        StringBuilder builder = new StringBuilder();
+        for (ArrayMsg item : array) {
+            // 仅处理文本类型消息
+            if (MsgTypeEnum.text.equals(item.getType())) {
+                builder.append(item.getStringData("text"));
+            }
+        }
+        return builder.toString();
+    }
+
+    /**
+     * 将消息字符串转换为纯文本
+     *
+     * @param msg 消息字符串
+     * @return 纯文本消息
+     */
+    public static String stringToPlainText(String msg) {
+        List<ArrayMsg> array = stringToArray(msg);
+        // 复用 arrayToPlainText 方法
+        return arrayToPlainText(array);
     }
 
 }

--- a/src/main/java/com/mikuac/shiro/dto/event/message/MessageEvent.java
+++ b/src/main/java/com/mikuac/shiro/dto/event/message/MessageEvent.java
@@ -50,14 +50,19 @@ public class MessageEvent extends Event {
     @JsonIgnore
     private List<ArrayMsg> arrayMsg;
 
+    @JsonIgnore
+    private String plainText;
+
     @JsonSetter("message")
     private void setMessageFromJson(JsonNode json) {
         if (json.isString()) {
             this.message = json.asString();
             this.arrayMsg = MessageConverser.stringToArray(message);
+            this.plainText = MessageConverser.arrayToPlainText(arrayMsg);
         } else if (json.isArray()) {
             this.arrayMsg = JsonUtils.parseArray(json, ArrayMsg.class);
-            message = MessageConverser.arraysToString(this.arrayMsg);
+            this.message = MessageConverser.arraysToString(arrayMsg);
+            this.plainText = MessageConverser.arrayToPlainText(arrayMsg);
         } else {
             throw new IllegalArgumentException("Invalid message format: " + json);
         }

--- a/src/main/java/com/mikuac/shiro/task/ShiroTaskPoolConfig.java
+++ b/src/main/java/com/mikuac/shiro/task/ShiroTaskPoolConfig.java
@@ -3,10 +3,13 @@ package com.mikuac.shiro.task;
 import com.mikuac.shiro.properties.TaskPoolProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnThreading;
+import org.springframework.boot.thread.Threading;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 
 /**
@@ -25,15 +28,38 @@ public class ShiroTaskPoolConfig {
         this.taskPoolProperties = taskPoolProperties;
     }
 
+
     /**
-     * 线程池配置
-     *
+     * 平台线程池
      * @return {@link ThreadPoolTaskExecutor}
      */
     @Bean("shiroTaskExecutor")
+    @ConditionalOnThreading(Threading.PLATFORM)
     @ConditionalOnProperty(value = "shiro.task-pool.enable-task-pool", havingValue = "true", matchIfMissing = true)
-    public ThreadPoolTaskExecutor shiroTaskExecutor() {
+    public ThreadPoolTaskExecutor shiroTaskPlatformExecutor() {
+        return getThreadPoolTaskExecutor(Thread.ofPlatform().factory());
+    }
+
+    /**
+     * 虚拟线程池
+     * @return {@link ThreadPoolTaskExecutor}
+     */
+    @Bean("shiroTaskExecutor")
+    @ConditionalOnThreading(Threading.VIRTUAL)
+    @ConditionalOnProperty(value = "shiro.task-pool.enable-task-pool", havingValue = "true", matchIfMissing = true)
+    public ThreadPoolTaskExecutor shiroTaskVirtualExecutor() {
+        return getThreadPoolTaskExecutor(Thread.ofVirtual().factory());
+    }
+
+
+    /**
+     * 初始化并获取线程池
+     * @param factory 线程工厂 {@link ThreadFactory}
+     * @return {@link ThreadPoolTaskExecutor}
+     */
+    private ThreadPoolTaskExecutor getThreadPoolTaskExecutor(ThreadFactory factory) {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setThreadFactory(factory);
         executor.setCorePoolSize(taskPoolProperties.getCorePoolSize());
         executor.setMaxPoolSize(taskPoolProperties.getMaxPoolSize());
         executor.setQueueCapacity(taskPoolProperties.getQueueCapacity());

--- a/src/test/java/com/mikuac/shiro/common/utils/MessageConverserTest.java
+++ b/src/test/java/com/mikuac/shiro/common/utils/MessageConverserTest.java
@@ -185,32 +185,29 @@ class MessageConverserTest {
         val msg = "[CQ:at,qq=1122334455]测试消息1[CQ:face,id=1]测试消息2[CQ:video,file=https://test.com/1.mp4][CQ:image,file=test1.image,url=https://test.com/1.jpg]\n[CQ:image,file=test2.image,url=https://test.com/2.jpg]";
         List<ArrayMsg> originalArrayMsgList = rawToArrayMsgOriginal(msg);
         List<ArrayMsg> optimizedArrayMsgList = MessageConverser.stringToArray(msg);
-
         assertEquals(originalArrayMsgList, optimizedArrayMsgList);
 
-        val originalCode = MessageConverser.arraysToString(originalArrayMsgList);
-        val optimizedCode = MessageConverser.arraysToString(optimizedArrayMsgList);
-
-        assertEquals(msg, originalCode);
-        assertEquals(msg, optimizedCode);
-        assertEquals(originalCode, optimizedCode);
+        val originalText = MessageConverser.arraysToString(originalArrayMsgList);
+        val optimizedText = MessageConverser.arraysToString(optimizedArrayMsgList);
+        val expectText = "测试消息1测试消息2\n";
+        assertEquals(expectText, originalText);
+        assertEquals(expectText, optimizedText);
+        assertEquals(originalText, optimizedText);
     }
 
     @Test
     void rawToArrayMsg3Test() {
         val msg = "[CQ:at,qq=1122334455]测试消息1[CQ:1111,id=1]测试消息2[CQ:video,file=https://test.com/1.mp4][CQ:image,file=test1.image,url=https://test.com/1.jpg]\n[CQ:image,file=test2.image,url=https://test.com/2.jpg]";
-        val expected = "[CQ:at,qq=1122334455]测试消息1[CQ:unknown,id=1]测试消息2[CQ:video,file=https://test.com/1.mp4][CQ:image,file=test1.image,url=https://test.com/1.jpg]\n[CQ:image,file=test2.image,url=https://test.com/2.jpg]";
         List<ArrayMsg> originalArrayMsgList = rawToArrayMsgOriginal(msg);
         List<ArrayMsg> optimizedArrayMsgList = MessageConverser.stringToArray(msg);
-
         assertEquals(originalArrayMsgList, optimizedArrayMsgList);
 
-        val originalCode = MessageConverser.arraysToString(originalArrayMsgList);
-        val optimizedCode = MessageConverser.arraysToString(optimizedArrayMsgList);
-
-        assertEquals(expected, originalCode);
-        assertEquals(expected, optimizedCode);
-        assertEquals(originalCode, optimizedCode);
+        val originalText = MessageConverser.arraysToString(originalArrayMsgList);
+        val optimizedText = MessageConverser.arraysToString(optimizedArrayMsgList);
+        val expectText = "测试消息1测试消息2\n";
+        assertEquals(expectText, originalText);
+        assertEquals(expectText, optimizedText);
+        assertEquals(originalText, optimizedText);
     }
 
     @Test

--- a/src/test/java/com/mikuac/shiro/common/utils/MessageConverserTest.java
+++ b/src/test/java/com/mikuac/shiro/common/utils/MessageConverserTest.java
@@ -181,33 +181,44 @@ class MessageConverserTest {
     }
 
     @Test
+    void testPlainMsgTest() {
+        val msg = "[CQ:at,qq=1122334455]测试消息1[CQ:face,id=1]测试消息2[CQ:video,file=https://test.com/1.mp4][CQ:image,file=test1.image,url=https://test.com/1.jpg]\n[CQ:image,file=test2.image,url=https://test.com/2.jpg]";
+        val expected = "测试消息1测试消息2\n";
+        val plainText = MessageConverser.stringToPlainText(msg);
+        assertEquals(expected, plainText);
+    }
+
+    @Test
     void rawToArrayMsg2Test() {
         val msg = "[CQ:at,qq=1122334455]测试消息1[CQ:face,id=1]测试消息2[CQ:video,file=https://test.com/1.mp4][CQ:image,file=test1.image,url=https://test.com/1.jpg]\n[CQ:image,file=test2.image,url=https://test.com/2.jpg]";
         List<ArrayMsg> originalArrayMsgList = rawToArrayMsgOriginal(msg);
         List<ArrayMsg> optimizedArrayMsgList = MessageConverser.stringToArray(msg);
+
         assertEquals(originalArrayMsgList, optimizedArrayMsgList);
 
-        val originalText = MessageConverser.arraysToString(originalArrayMsgList);
-        val optimizedText = MessageConverser.arraysToString(optimizedArrayMsgList);
-        val expectText = "测试消息1测试消息2\n";
-        assertEquals(expectText, originalText);
-        assertEquals(expectText, optimizedText);
-        assertEquals(originalText, optimizedText);
+        val originalCode = MessageConverser.arraysToString(originalArrayMsgList);
+        val optimizedCode = MessageConverser.arraysToString(optimizedArrayMsgList);
+
+        assertEquals(msg, originalCode);
+        assertEquals(msg, optimizedCode);
+        assertEquals(originalCode, optimizedCode);
     }
 
     @Test
     void rawToArrayMsg3Test() {
         val msg = "[CQ:at,qq=1122334455]测试消息1[CQ:1111,id=1]测试消息2[CQ:video,file=https://test.com/1.mp4][CQ:image,file=test1.image,url=https://test.com/1.jpg]\n[CQ:image,file=test2.image,url=https://test.com/2.jpg]";
+        val expected = "[CQ:at,qq=1122334455]测试消息1[CQ:unknown,id=1]测试消息2[CQ:video,file=https://test.com/1.mp4][CQ:image,file=test1.image,url=https://test.com/1.jpg]\n[CQ:image,file=test2.image,url=https://test.com/2.jpg]";
         List<ArrayMsg> originalArrayMsgList = rawToArrayMsgOriginal(msg);
         List<ArrayMsg> optimizedArrayMsgList = MessageConverser.stringToArray(msg);
+
         assertEquals(originalArrayMsgList, optimizedArrayMsgList);
 
-        val originalText = MessageConverser.arraysToString(originalArrayMsgList);
-        val optimizedText = MessageConverser.arraysToString(optimizedArrayMsgList);
-        val expectText = "测试消息1测试消息2\n";
-        assertEquals(expectText, originalText);
-        assertEquals(expectText, optimizedText);
-        assertEquals(originalText, optimizedText);
+        val originalCode = MessageConverser.arraysToString(originalArrayMsgList);
+        val optimizedCode = MessageConverser.arraysToString(optimizedArrayMsgList);
+
+        assertEquals(expected, originalCode);
+        assertEquals(expected, optimizedCode);
+        assertEquals(originalCode, optimizedCode);
     }
 
     @Test


### PR DESCRIPTION
在以下配置中进行设置，即可开启虚拟线程池
```yaml
spring:
  threads:
    virtual:
      enabled: true # 默认是 false，也就是默认采用平台线程，反之使用虚拟线程
```
新增的`plainText`字段将利于消息过滤匹配，以及开发者提取纯文本消息
```java
@Shiro
@Component
@Slf4j
public class TestPlugin {

    @AnyMessageHandler
    @MessageHandlerFilter(matchPlainText = true)
    public void testPlugin(AnyMessageEvent event) {
        log.info("testPlugin plainMsg = {}", event.getPlainText()); // testPlugin plainMsg = /test
        log.info("testPlugin msg = {}", event.getMessage()); // testPlugin msg = [CQ:reply,id=14261461]/test
        log.info("testPlugin raw_msg = {}", event.getRawMessage()); // testPlugin raw_msg = [CQ:reply,id=14261461]/test
    }

    @AnyMessageHandler
    @MessageHandlerFilter(reply = ReplyEnum.REPLY_ALL, cmd = "/test", matchPlainText = true)
    public void testPlainPlugin(AnyMessageEvent event) {
        log.info("testPlainTextPlugin plainMsg = {}", event.getPlainText()); // testPlainTextPlugin plainMsg = /test
        log.info("testPlainTextPlugin msg = {}", event.getMessage()); // testPlainTextPlugin msg = [CQ:reply,id=14261461]/test
        log.info("testPlainTextPlugin raw_msg = {}", event.getRawMessage()); // testPlainTextPlugin raw_msg = [CQ:reply,id=14261461]/test
    }

    @AnyMessageHandler
    @MessageHandlerFilter(reply = ReplyEnum.REPLY_ALL, cmd = "\\[CQ:reply,id=\\d+\\]\\s*(/test)") // 不匹配纯文本
    public void testMessagePlugin(AnyMessageEvent event) {
        log.info("testMessagePlugin plainMsg = {}", event.getPlainText());// testMessagePlugin plainMsg = /test
        log.info("testMessagePlugin msg = {}", event.getMessage());// testMessagePlugin msg = [CQ:reply,id=14261461]/test
        log.info("testMessagePlugin raw_msg = {}", event.getRawMessage());// testMessagePlugin raw_msg = [CQ:reply,id=14261461]/test

    }
}
```

## Summary by Sourcery

为纯文本消息提取和可配置的正则匹配方式提供支持（可选择对纯文本或完整消息进行匹配），并为 Shiro 任务新增独立的平台线程池和虚拟线程池执行器。

New Features:
- 在消息事件上暴露一个 `plainText` 字段，从解析后的消息数组中派生而来，用于更方便地获取纯文本内容。
- 允许消息处理器的过滤器选择正则命令是匹配纯文本内容还是完整的原始消息，默认使用纯文本匹配。
- 为 Shiro 任务提供独立的平台线程和虚拟线程执行器，并由 Spring 的线程配置进行控制。

Enhancements:
- 添加工具方法，将消息字符串和数组转换为纯文本，忽略 CQ 码。
- 调整消息转换逻辑，使其能够从 `ArrayMsg` 元素正确重建消息字符串。

Build:
- 将项目版本从 `2.5.3` 升级到 `2.5.5`。

Tests:
- 新增单元测试，验证 `stringToPlainText` 能够从包含混合 CQ 码的消息中正确提取出仅包含文本的部分。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for plain-text message extraction and configurable regex matching against plain text or full messages, and introduce separate platform and virtual thread pool executors for Shiro tasks.

New Features:
- Expose a plainText field on message events derived from the parsed message array for easier access to pure text content.
- Allow message handler filters to choose whether regex commands match against pure text content or the full raw message, defaulting to plain-text matching.
- Provide separate Shiro task executors for platform and virtual threads controlled by Spring threading configuration.

Enhancements:
- Add utilities to convert message strings and arrays to pure text, ignoring CQ codes.
- Adjust message conversion logic to correctly rebuild message strings from ArrayMsg elements.

Build:
- Bump project version from 2.5.3 to 2.5.5.

Tests:
- Add a unit test verifying that stringToPlainText correctly extracts only the text portions from mixed CQ-code messages.

</details>