### PR TITLE
Refactor WebSocket session handling: extract `parseSelfIdFromHeader` …

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@
 import org.jreleaser.model.Active
 
 group = "com.mikuac"
-version = "2.5.2"
+version = "2.5.2-fix"
 
 val mavenArtifactResolver = "1.9.27"
 val mavenResolverProvider = "3.9.12"

--- a/src/main/java/com/mikuac/shiro/adapter/WebSocketServerHandler.java
+++ b/src/main/java/com/mikuac/shiro/adapter/WebSocketServerHandler.java
@@ -78,13 +78,7 @@ public class WebSocketServerHandler extends TextWebSocketHandler {
             session.setBinaryMessageSizeLimit(wsProp.getMaxBinaryMessageBufferSize());
             var attributes = session.getAttributes();
             attributes.put(Connection.ADAPTER_KEY, AdapterEnum.SERVER);
-            long xSelfId = ConnectionUtils.parseSelfIdFromHeader(session);
-            if (xSelfId == 0L) {
-                log.error("Failed parse x-self-id for websocket session");
-                session.close();
-                return;
-            }
-            attributes.put(Connection.X_SELF_ID, xSelfId);
+            long xSelfId = ConnectionUtils.parseSelfId(session);
 
             if (!ConnectionUtils.checkToken(session, wsProp.getAccessToken())) {
                 log.error("Invalid access token");

--- a/src/main/java/com/mikuac/shiro/adapter/WebSocketServerHandler.java
+++ b/src/main/java/com/mikuac/shiro/adapter/WebSocketServerHandler.java
@@ -76,13 +76,16 @@ public class WebSocketServerHandler extends TextWebSocketHandler {
         try {
             session.setTextMessageSizeLimit(wsProp.getMaxTextMessageBufferSize());
             session.setBinaryMessageSizeLimit(wsProp.getMaxBinaryMessageBufferSize());
-            session.getAttributes().put(Connection.ADAPTER_KEY, AdapterEnum.SERVER);
-            long xSelfId = ConnectionUtils.parseSelfId(session);
+            var attributes = session.getAttributes();
+            attributes.put(Connection.ADAPTER_KEY, AdapterEnum.SERVER);
+            long xSelfId = ConnectionUtils.parseSelfIdFromHeader(session);
             if (xSelfId == 0L) {
                 log.error("Failed parse x-self-id for websocket session");
                 session.close();
                 return;
             }
+            attributes.put(Connection.X_SELF_ID, xSelfId);
+
             if (!ConnectionUtils.checkToken(session, wsProp.getAccessToken())) {
                 log.error("Invalid access token");
                 session.close();

--- a/src/main/java/com/mikuac/shiro/boot/ShiroAutoConfiguration.java
+++ b/src/main/java/com/mikuac/shiro/boot/ShiroAutoConfiguration.java
@@ -4,6 +4,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import com.mikuac.shiro.adapter.WebSocketClientHandler;
 import com.mikuac.shiro.adapter.WebSocketServerHandler;
+import com.mikuac.shiro.constant.Connection;
 import com.mikuac.shiro.properties.ShiroProperties;
 import com.mikuac.shiro.properties.WebSocketClientProperties;
 import com.mikuac.shiro.properties.WebSocketProperties;
@@ -15,15 +16,22 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.lang.Nullable;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.WebSocketHttpHeaders;
 import org.springframework.web.socket.client.WebSocketConnectionManager;
 import org.springframework.web.socket.client.standard.StandardWebSocketClient;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.HandshakeInterceptor;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -40,7 +48,7 @@ import java.util.concurrent.TimeUnit;
 @EnableWebSocket
 @Import(Shiro.class)
 @ComponentScan("com.mikuac.shiro")
-public class ShiroAutoConfiguration implements WebSocketConfigurer {
+public class ShiroAutoConfiguration implements WebSocketConfigurer , HandshakeInterceptor {
 
     private final WebSocketServerProperties wsServerProp;
     private final WebSocketClientProperties wsClientProp;
@@ -79,7 +87,10 @@ public class ShiroAutoConfiguration implements WebSocketConfigurer {
             return;
         }
         if (Boolean.TRUE.equals(wsServerProp.getEnable())) {
-            registry.addHandler(webSocketServerHandler, wsServerProp.getUrl()).setAllowedOrigins("*");
+            registry
+                    .addHandler(webSocketServerHandler, wsServerProp.getUrl())
+                    .addInterceptors(this)
+                    .setAllowedOrigins("*");
         }
         if (Boolean.TRUE.equals(wsClientProp.getEnable())) {
             createWebsocketClient();
@@ -111,4 +122,36 @@ public class ShiroAutoConfiguration implements WebSocketConfigurer {
         }, 0, wsClientProp.getReconnectInterval(), TimeUnit.SECONDS);
     }
 
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+        var headers = request.getHeaders();
+        String selfIdStr = getAttributes(headers, attributes, Connection.X_SELF_ID, "no number");
+        long selfId;
+        try {
+            selfId = Long.parseLong(selfIdStr);
+            attributes.put(Connection.X_SELF_ID, selfId);
+        } catch (NumberFormatException e) {
+            return false;
+        }
+
+        String authorization = getAttributes(headers, attributes, "authorization", "");
+        attributes.put("authorization", authorization);
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, @Nullable Exception exception) {
+        // ignore
+    }
+
+    private String getAttributes(HttpHeaders headers, Map<String, Object> attributes, String key, String defaultValue) {
+        Object result  = headers.getFirst(key);
+        if (result == null) {
+            result = attributes.get(key);
+        }
+        if (result == null) {
+            return defaultValue;
+        }
+        return result.toString();
+    }
 }

--- a/src/main/java/com/mikuac/shiro/common/utils/ConnectionUtils.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/ConnectionUtils.java
@@ -71,6 +71,16 @@ public class ConnectionUtils {
         return bot;
     }
 
+    public static long parseSelfIdFromHeader(WebSocketSession session) {
+        String selfIdStr = Optional.ofNullable(session.getHandshakeHeaders().getFirst(Connection.X_SELF_ID))
+                .orElse((String) session.getAttributes().get(Connection.X_SELF_ID));
+        try {
+            return Long.parseLong(selfIdStr);
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
+    }
+
     /**
      * 获取连接的 QQ 号
      *
@@ -78,10 +88,17 @@ public class ConnectionUtils {
      * @return QQ 号
      */
     public static long parseSelfId(WebSocketSession session) {
-        String selfIdStr = Optional.ofNullable(session.getHandshakeHeaders().getFirst(Connection.X_SELF_ID))
-                .orElse((String) session.getAttributes().get(Connection.X_SELF_ID));
+        Object selfIdObj = session.getAttributes().get(Connection.X_SELF_ID);
+        if (selfIdObj == null) {
+            return 0L;
+        }
+
+        if (selfIdObj instanceof Long i) {
+            return i;
+        }
+
         try {
-            return Long.parseLong(selfIdStr);
+            return Long.parseLong(selfIdObj.toString());
         } catch (NumberFormatException e) {
             return 0L;
         }

--- a/src/main/java/com/mikuac/shiro/common/utils/ConnectionUtils.java
+++ b/src/main/java/com/mikuac/shiro/common/utils/ConnectionUtils.java
@@ -71,16 +71,6 @@ public class ConnectionUtils {
         return bot;
     }
 
-    public static long parseSelfIdFromHeader(WebSocketSession session) {
-        String selfIdStr = Optional.ofNullable(session.getHandshakeHeaders().getFirst(Connection.X_SELF_ID))
-                .orElse((String) session.getAttributes().get(Connection.X_SELF_ID));
-        try {
-            return Long.parseLong(selfIdStr);
-        } catch (NumberFormatException e) {
-            return 0L;
-        }
-    }
-
     /**
      * 获取连接的 QQ 号
      *
@@ -105,7 +95,7 @@ public class ConnectionUtils {
     }
 
     public static String getAuthorization(WebSocketSession session) {
-        return session.getHandshakeHeaders().getFirst("authorization");
+        return session.getAttributes().getOrDefault("authorization", "").toString();
     }
 
     /**

--- a/src/main/java/com/mikuac/shiro/core/CoreEvent.java
+++ b/src/main/java/com/mikuac/shiro/core/CoreEvent.java
@@ -34,9 +34,10 @@ public class CoreEvent {
     }
 
     /**
-     * 可以通过 session.getHandshakeHeaders().getFirst("x-self-id") 获取上线的机器人账号
+     * 可以通过 ConnectionUtils.parseSelfId(session) 获取上线的机器人账号
      * 例如当服务端为开放服务时，并且只有白名单内的账号才允许连接，此时可以检查账号是否存在于白名内
      * 不存在的话返回 false 即可禁止连接
+     * spring 4 更新后禁止通过 session 访问 getHandshakeHeaders!
      *
      * @param session {@link WebSocketSession}
      * @return 返回值为 false 时会中断 ws 会话


### PR DESCRIPTION
关联issue [url](https://github.com/MisakaTAT/Shiro/issues/382)

## Summary by Sourcery

重构 WebSocket 会话处理逻辑，将基于请求头的 self ID 解析与基于属性的解析分离，并确保在服务器建立连接时把解析得到的 self ID 存入会话属性中。

增强点：
- 引入专用的辅助方法，从 WebSocket 握手请求头中解析 self ID，并在值无效时实现平滑回退。
- 调整 WebSocket 服务器连接建立流程，使用基于请求头的 self ID 解析，并将验证后的 ID 持久化到会话属性中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor WebSocket session handling to separate header-based self ID parsing from attribute-based parsing and ensure the parsed self ID is stored in the session attributes during server connection setup.

Enhancements:
- Introduce a dedicated helper to parse the self ID from WebSocket handshake headers with graceful fallback on invalid values.
- Adjust WebSocket server connection establishment to use header-based self ID parsing and persist the validated ID into session attributes.

</details>