### PR TITLE
针对napcat的超出限制的msg_id的合并转发消息的解析

### DIFF
--- a/src/main/java/com/mikuac/shiro/action/NapCatExtend.java
+++ b/src/main/java/com/mikuac/shiro/action/NapCatExtend.java
@@ -2,6 +2,7 @@ package com.mikuac.shiro.action;
 
 import com.mikuac.shiro.dto.action.common.ActionData;
 import com.mikuac.shiro.dto.action.common.ActionRaw;
+import com.mikuac.shiro.dto.action.response.GetForwardMsgResp;
 import com.mikuac.shiro.dto.action.response.GetMsgListResp;
 
 public interface NapCatExtend {
@@ -43,4 +44,11 @@ public interface NapCatExtend {
      * @return result {@link ActionRaw}
      */
     ActionRaw setMsgEmojiLike(int msgId, String code, boolean isSet);
+
+    /**
+     * 获取合并转发消息，使用String类型的msgId
+     * @param msgId - 消息ID
+     * @return result {@link ActionData} of {@link GetForwardMsgResp}
+     */
+    ActionData<GetForwardMsgResp> getForwardMsg(String msgId);
 }

--- a/src/main/java/com/mikuac/shiro/core/Bot.java
+++ b/src/main/java/com/mikuac/shiro/core/Bot.java
@@ -1624,6 +1624,20 @@ public class Bot
     }
 
     /**
+     * 获取合并转发消息
+     * @param msgId - 消息ID
+     * @return result {@link ActionData} of {@link GetForwardMsgResp}
+     */
+    @Override
+    public ActionData<GetForwardMsgResp> getForwardMsg(String msgId) {
+        Map<String, Object> params = new HashMap<>();
+        params.put(ActionParams.MESSAGE_ID, msgId);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.GET_FORWARD_MSG, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
+    }
+
+    /**
      * 自定义请求
      *
      * @param action 请求路径


### PR DESCRIPTION
在NapCatExtend接口下新增 getForwardMsg(String msgId)
~~对#385 问题的可选解决方案~~ 并没有完全解决问题，只支持了解析合并转发消息

## Summary by Sourcery

在 NapCat 扩展和机器人核心中添加对使用字符串消息 ID 获取合并转发消息的支持。

新功能：
- 在 `NapCatExtend` 接口中引入基于字符串的 `getForwardMsg` API，用于获取合并转发消息。
- 在 `Bot` 类中实现相应的 `getForwardMsg(String msgId)` 处理方法，以处理字符串类型的消息 ID。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for retrieving merged forward messages using string-based message IDs in the NapCat extension and bot core.

New Features:
- Introduce a string-based getForwardMsg API in the NapCatExtend interface for fetching merged forward messages.
- Implement the corresponding getForwardMsg(String msgId) handler in the Bot class to process string message IDs.

</details>