### PR TITLE
✨ 新增QQ空间说说发布与删除功能

### DIFF
--- a/src/main/java/com/mikuac/shiro/action/NapCatExtend.java
+++ b/src/main/java/com/mikuac/shiro/action/NapCatExtend.java
@@ -3,6 +3,9 @@ package com.mikuac.shiro.action;
 import com.mikuac.shiro.dto.action.common.ActionData;
 import com.mikuac.shiro.dto.action.common.ActionRaw;
 import com.mikuac.shiro.dto.action.response.GetMsgListResp;
+import com.mikuac.shiro.dto.action.response.SendQzoneResp;
+
+import java.util.List;
 
 public interface NapCatExtend {
 
@@ -43,4 +46,22 @@ public interface NapCatExtend {
      * @return result {@link ActionRaw}
      */
     ActionRaw setMsgEmojiLike(int msgId, String code, boolean isSet);
+
+
+    /**
+     * 发表QQ空间说说
+     * @param content 说说正文
+     * @param richvals 每张图片对应的richval数组, 为空表示纯文字说说
+     * @param ugcRight 查看权限 1所有人可见 4好友可见 16部分好友可见 64仅自己可见 128部分好友不可见
+     * @param targetUins 权限作用QQ号数组, ugcRight为16/128时使用
+     * @return {@link ActionData} of {@link SendQzoneResp}
+     */
+    ActionData<SendQzoneResp> publishQzoneMsg(String content, List<String> richvals, int ugcRight, List<Integer> targetUins);
+
+    /**
+     * 删除QQ空间说说
+     * @param tid 说说Tid, 来自 publishQzoneMsg 的返回值
+     * @return result {@link ActionRaw}
+     */
+    ActionRaw deleteQzoneMsg(String tid);
 }

--- a/src/main/java/com/mikuac/shiro/constant/ActionParams.java
+++ b/src/main/java/com/mikuac/shiro/constant/ActionParams.java
@@ -59,6 +59,10 @@ public class ActionParams {
     public static final String SOURCE = "source";
     public static final String EMOJI_ID = "emoji_id";
     public static final String SET = "set";
+    public static final String IMAGES = "images";
+    public static final String UGC_RIGHT = "ugc_right";
+    public static final String TARGET_UINS = "target_uins";
+    public static final String TID = "tid";
 
     private ActionParams() {
     }

--- a/src/main/java/com/mikuac/shiro/core/Bot.java
+++ b/src/main/java/com/mikuac/shiro/core/Bot.java
@@ -1540,6 +1540,46 @@ public class Bot
         }) : null;
     }
 
+    /**
+     * 发表QQ空间说说
+     *
+     * @param content    说说正文
+     * @param richvals   每张图片对应的richval数组, 为空表示纯文字说说
+     * @param ugcRight   查看权限 1所有人可见 4好友可见 16部分好友可见 64仅自己可见 128部分好友不可见
+     * @param targetUins 权限作用QQ号数组, ugcRight为16/128时使用
+     * @return result {@link ActionData} of {@link SendQzoneResp}
+     */
+    @Override
+    public ActionData<SendQzoneResp> publishQzoneMsg(String content, List<String> richvals, int ugcRight,
+            List<Integer> targetUins) {
+        Map<String, Object> params = new HashMap<>();
+        params.put(ActionParams.CONTENT, content);
+        if (richvals != null && !richvals.isEmpty()) {
+            params.put(ActionParams.IMAGES, richvals);
+        }
+        params.put(ActionParams.UGC_RIGHT, ugcRight);
+        if (targetUins != null && !targetUins.isEmpty()) {
+            params.put(ActionParams.TARGET_UINS, targetUins);
+        }
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.SEND_QZONE_MSG, params);
+        return result != null ? JsonUtils.readValue(result.toJSONString(), new TypeReference<>() {
+        }) : null;
+    }
+
+    /**
+     * 删除QQ空间说说
+     *
+     * @param tid 说说Tid, 来自 publishQzoneMsg 的返回值
+     * @return result {@link ActionRaw}
+     */
+    @Override
+    public ActionRaw deleteQzoneMsg(String tid) {
+        Map<String, Object> params = new HashMap<>();
+        params.put(ActionParams.TID, tid);
+        JsonObjectWrapper result = actionHandler.action(session, ActionPathEnum.DELETE_QZONE_MSG, params);
+        return result != null ? result.to(ActionRaw.class) : null;
+    }
+
     private ActionRaw doPoke(ActionPathEnum path, Consumer<Map<String, Object>> paramFiller) {
         Map<String, Object> params = new HashMap<>();
         paramFiller.accept(params);

--- a/src/main/java/com/mikuac/shiro/dto/action/response/SendQzoneResp.java
+++ b/src/main/java/com/mikuac/shiro/dto/action/response/SendQzoneResp.java
@@ -1,0 +1,8 @@
+package com.mikuac.shiro.dto.action.response;
+
+import lombok.Data;
+
+@Data
+public class SendQzoneResp {
+    private String tid;
+}

--- a/src/main/java/com/mikuac/shiro/enums/ActionPathEnum.java
+++ b/src/main/java/com/mikuac/shiro/enums/ActionPathEnum.java
@@ -310,7 +310,15 @@ public enum ActionPathEnum implements ActionPath {
     /**
      * 获取合并转发消息
      */
-    GET_FORWARD_MSG("get_forward_msg");
+    GET_FORWARD_MSG("get_forward_msg"),
+    /**
+     * 发表QQ空间说说
+     */
+    SEND_QZONE_MSG("send_qzone_msg"),
+    /**
+     * 删除QQ空间说说
+     */
+    DELETE_QZONE_MSG("delete_qzone_msg");
 
     /**
      * 请求路径


### PR DESCRIPTION
## Summary by Sourcery

通过机器人动作 API 新增对 QQ 空间说说发布和删除的支持。

新功能：
- 在 NapCatExtend 接口和 Bot 实现中暴露 `publishQzoneMsg` 和 `deleteQzoneMsg` 操作，用于创建和删除 QQ 空间说说，并可配置可见范围和目标用户。

改进：
- 扩展动作路径和参数常量以覆盖 QQ 空间说说的发布、删除及相关元数据，并为 QQ 空间发布结果引入响应 DTO。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for publishing and deleting QQ Zone posts through the bot action APIs.

New Features:
- Expose publishQzoneMsg and deleteQzoneMsg operations in the NapCatExtend interface and Bot implementation to create and remove QQ Zone posts with configurable visibility and target users.

Enhancements:
- Extend action path and parameter constants to cover QQ Zone posting, deletion, and related metadata, and introduce a response DTO for QQ Zone publish results.

</details>